### PR TITLE
Rename internal functions for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ exitSuccess' = send ExitSuccess
 --------------------------------------------------------------------------------
 runTeletype :: Eff '[Teletype] w -> IO w
 runTeletype (Val x) = return x
-runTeletype (E u q) = case decomp u of
+runTeletype (E u q) = case decompose u of
               Right (PutStrLn msg) -> putStrLn msg  >> runTeletype (qApp q ())
               Right GetLine        -> getLine      >>= \s -> runTeletype (qApp q s)
               Right ExitSuccess    -> exitSuccess
@@ -71,7 +71,7 @@ runTeletypePure inputs req = reverse (go inputs req [])
   where go :: [String] -> Eff '[Teletype] w -> [String] -> [String]
         go _      (Val _) acc = acc
         go []     _       acc = acc
-        go (x:xs) (E u q) acc = case decomp u of
+        go (x:xs) (E u q) acc = case decompose u of
           Right (PutStrLn msg) -> go (x:xs) (qApp q ()) (msg:acc)
           Right GetLine        -> go xs     (qApp q x) acc
           Right ExitSuccess    -> go xs     (Val ())   acc

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ LICENSE file for more details.
 This package would not be possible without the paper and the reference
 implementation. In particular:
 
-* Data.Open.Union maps to [OpenUnion51.hs](http://okmij.org/ftp/Haskell/extensible/OpenUnion51.hs)
+* Data.Union maps to [OpenUnion51.hs](http://okmij.org/ftp/Haskell/extensible/OpenUnion51.hs)
 * Data.FTCQueue maps to [FTCQueue1](http://okmij.org/ftp/Haskell/extensible/FTCQueue1.hs)
 * Control.Monad.Effect* maps to [Eff1.hs](http://okmij.org/ftp/Haskell/extensible/Eff1.hs)
 

--- a/bench/Core.hs
+++ b/bench/Core.hs
@@ -70,12 +70,12 @@ post' = send . Post
 get' :: (Http :< r) => Eff r String
 get' = send Get
 
-runHttp :: Eff (Http ': r) w -> Eff r w
-runHttp (Val x) = pure x
-runHttp (E u q) = case decomp u of
+runHttp :: Eff (Http ': e) b -> Eff e b
+runHttp (Val b) = pure b
+runHttp (E u q) = case decompose u of
   Right (Open _) -> runHttp (q `apply` ())
   Right Close    -> runHttp (q `apply` ())
-  Right (Post d) -> runHttp (q `apply` d)
+  Right (Post a) -> runHttp (q `apply` a)
   Right Get      -> runHttp (q `apply` "")
   Left u'        -> E u' $ tsingleton (runHttp . apply q)
 

--- a/effects.cabal
+++ b/effects.cabal
@@ -48,7 +48,7 @@ library
                      , Control.Monad.Effect.Writer
                      , Control.Monad.Effect.NonDetEff
                      , Data.FTCQueue
-                     , Data.Open.Union
+                     , Data.Union
   build-depends:       base >=4.7 && <5
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/examples/src/Teletype.hs
+++ b/examples/src/Teletype.hs
@@ -28,7 +28,7 @@ exitSuccess' = send ExitSuccess
 -- Runs a Teletype effect b and returns IO b.
 run :: Eff '[Teletype] a -> IO a
 run (Val x) = pure x
-run (E u q) = case decomp u of
+run (E u q) = case decompose u of
   Right (PutStrLn msg) -> putStrLn msg  >> Teletype.run (apply q ())
   Right GetLine        -> getLine      >>= \s -> Teletype.run (apply q s)
   Right ExitSuccess    -> exitSuccess
@@ -41,11 +41,11 @@ runPure inputs req = reverse (go inputs req [])
   where go :: [String] -> Eff '[Teletype] w -> [String] -> [String]
         go _  (Val _) acc = acc
         go xs (E u q) acc = case xs of
-          (x:xs') -> case decomp u of
+          (x:xs') -> case decompose u of
             Right (PutStrLn msg) -> go (x:xs') (apply q ()) (msg:acc)
             Right GetLine        -> go xs'     (apply q x) acc
             Right ExitSuccess    -> go xs'     (Val ())   acc
             Left _               -> go xs'     (Val ())   acc
-          _      -> case decomp u of
+          _      -> case decompose u of
             Right (PutStrLn msg) -> go xs (apply q ()) (msg:acc)
             _                    -> go xs     (Val ())   acc

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-|
 Module      : Control.Monad.Effect
-Description : Freer - an extensible effects library
+Description : Effects - an extensible effects library
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -5,7 +5,7 @@
 
 {-|
 Module      : Control.Monad.Effect.Coroutine
-Description : Composable coroutine effects layer.
+Description : Composable Coroutine effects
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Control/Monad/Effect/Cut.hs
+++ b/src/Control/Monad/Effect/Cut.hs
@@ -39,7 +39,7 @@ cutFalse = throwError CutFalse
 call :: (Exc CutFalse :< r) => Eff (Exc CutFalse ': r) a -> Eff r a
 call m = loop [] m where
  loop jq (Val x) = return x `mplus` next jq          -- (C2)
- loop jq (E u q) = case decomp u of
+ loop jq (E u q) = case decompose u of
     Right (Exc CutFalse) -> mzero  -- drop jq (F2)
     Left u -> check jq u
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -40,7 +40,7 @@ module Control.Monad.Effect.Internal (
   interpose,
 ) where
 
-import Data.Open.Union
+import Data.Union
 import Data.FTCQueue
 
 -- | An effectful computation that returns 'b' and sends a list of 'effects'.

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -22,7 +22,7 @@ module Control.Monad.Effect.Internal (
   inj,
   prj,
   -- * Constructing and Decomposing Queues
-  decomp,
+  decompose,
   Arrow,
   tsingleton,
   Queue,
@@ -106,7 +106,7 @@ run _       = error "Internal:run - This (E) should never happen"
 -- This is useful for plugging in traditional transformer stacks.
 runM :: Monad m => Eff '[m] a -> m a
 runM (Val x) = pure x
-runM (E u q) = case decomp u of
+runM (E u q) = case decompose u of
   Right m -> m >>= runM . (apply q)
   Left _   -> error "Internal:runM - This (Left) should never happen"
 
@@ -121,7 +121,7 @@ relay :: Arrow e a b -- ^ An 'pure' effectful arrow.
 relay pure' bind = loop
  where
   loop (Val x)  = pure' x
-  loop (E u' q)  = case decomp u' of
+  loop (E u' q)  = case decompose u' of
     Right x -> bind x k
     Left  u -> E u (tsingleton k)
    where k = q >>> loop
@@ -137,7 +137,7 @@ relayState :: s
 relayState s' pure' bind = loop s'
   where
     loop s (Val x)  = pure' s x
-    loop s (E u' q)  = case decomp u' of
+    loop s (E u' q)  = case decompose u' of
       Right x -> bind s x k
       Left  u -> E u (tsingleton (k s))
      where k s'' x = loop s'' $ q `apply` x

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -21,13 +21,13 @@ module Control.Monad.Effect.Internal (
   -- | Inserts multiple effects into 'E'.
   inj,
   prj,
-  -- * Constructing and Decomposing Queues
+  -- * Constructing and Decomposing Queues of Effects
   decompose,
-  Arrow,
-  tsingleton,
   Queue,
+  tsingleton,
+  Arrow,
   Union,
-  -- * Composing and Applying Queues
+  -- * Composing and Applying Effects
   apply,
   (<<<),
   (>>>),
@@ -43,18 +43,18 @@ module Control.Monad.Effect.Internal (
 import Data.Open.Union
 import Data.FTCQueue
 
--- | An effectful computation that returns 'b' and performs 'effects'.
+-- | An effectful computation that returns 'b' and sends a list of 'effects'.
 data Eff effects b
-  -- | Done with the value of type b.
+  -- | Done with the value of type `b`.
   = Val b
-  -- | Send a request of type 'Union e a' with the 'Arrs e a b' queue.
+  -- | Send an union of 'effects' and 'eff a' to handle, and a queues of effects to apply from 'a' to 'b'.
   | forall a. E (Union effects a) (Queue effects a b)
 
--- | A queue of 'effects' from 'a' to 'b'.
+-- | A queue of effects to apply from 'a' to 'b'.
 type Queue effects a b = FTCQueue (Eff effects) a b
 
 -- | An effectful function from 'a' to 'b'
---   that also performs 'effects'.
+--   that also performs a list of 'effects'.
 type Arrow effects a b = a -> Eff effects b
 
 -- * Composing and Applying Effects
@@ -82,7 +82,7 @@ apply q' x =
 
 -- * Sending and Running Effects
 
--- | Send a request and wait for a reply.
+-- | Send a effect and wait for a reply.
 send :: (eff :< e) => eff b -> Eff e b
 send t = E (inj t) (tsingleton Val)
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -72,13 +72,13 @@ apply q' x =
 (>>>) :: Queue effects a b
       -> (Eff effects b -> Eff effects' c) -- ^ An function to compose.
       -> Arrow effects' a c
-(>>>) arrows f = f . apply arrows
+(>>>) queue f = f . apply queue
 
 -- | Compose queues right to left.
 (<<<) :: (Eff effects b -> Eff effects' c) -- ^ An function to compose.
       -> Queue effects  a b
       -> Arrow effects' a c
-(<<<) f arrows  = f . apply arrows
+(<<<) f queue  = f . apply queue
 
 -- * Sending and Running Effects
 

--- a/src/Control/Monad/Effect/NonDetEff.hs
+++ b/src/Control/Monad/Effect/NonDetEff.hs
@@ -1,4 +1,16 @@
 {-# LANGUAGE TypeOperators, GADTs, FlexibleContexts, UndecidableInstances, DataKinds #-}
+
+{-|
+Module      : Control.Monad.Effect.NonDetEff
+Description : Nondeterministic Choice effects
+Copyright   : Alej Cabrera 2015
+License     : BSD-3
+Maintainer  : cpp.cabrera@gmail.com
+Stability   : experimental
+Portability : POSIX
+-}
+
+
 module Control.Monad.Effect.NonDetEff (
   NonDetEff(..),
   makeChoiceA,

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -6,7 +6,7 @@
 
 {-|
 Module      : Control.Monad.Effect.Reader
-Description : Reader effects, for encapsulating an environment
+Description : Reader effects for computations that carry an environment
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -54,12 +54,12 @@ modify :: (State s :< e) => (s -> s) -> Eff e ()
 modify f = fmap f get >>= put
 
 -- | Handler for State effects
-runState :: Eff (State s ': e) w -> s -> Eff e (w, s)
-runState (Val x) s = pure (x,s)
+runState :: Eff (State s ': e) b -> s -> Eff e (b, s)
+runState (Val b) s = pure (b, s)
 runState (E u q) s = case decomp u of
   Right Get      -> runState (apply q s) s
   Right (Put s') -> runState (apply q ()) s'
-  Left  u'       -> E u' (tsingleton (\x -> runState (apply q x) s))
+  Left  u'       -> E u' (tsingleton (\a -> runState (apply q a) s))
 
 
 -- |

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -36,6 +36,15 @@ import Data.Proxy
                          -- State, strict --
 --------------------------------------------------------------------------------
 
+-- | Run a 'State s' effect given an effect and an initial state.
+runState :: Eff (State s ': e) b -> s -> Eff e (b, s)
+runState (Val b) s = pure (b, s)
+runState (E u q) s = case decompose u of
+  Left  u'       -> E u' $ tsingleton (flip runState s . apply q)
+  Right Get      -> runState (apply q s) s
+  Right (Put s') -> runState (apply q ()) s'
+
+
 -- | Strict State effects: one can either Get values or Put them
 data State s v where
   Get :: State s s
@@ -52,15 +61,6 @@ put s = send (Put s)
 -- | Modify state
 modify :: (State s :< e) => (s -> s) -> Eff e ()
 modify f = fmap f get >>= put
-
--- | Handler for State effects
-runState :: Eff (State s ': e) b -> s -> Eff e (b, s)
-runState (Val b) s = pure (b, s)
-runState (E u q) s = case decompose u of
-  Right Get      -> runState (apply q s) s
-  Right (Put s') -> runState (apply q ()) s'
-  Left  u'       -> E u' (tsingleton (\a -> runState (apply q a) s))
-
 
 -- |
 -- An encapsulated State handler, for transactional semantics

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -6,7 +6,7 @@
 
 {-|
 Module      : Control.Monad.Effect.State
-Description : State effects, for state-carrying computations.
+Description : State effects for computations that carry state
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -56,7 +56,7 @@ modify f = fmap f get >>= put
 -- | Handler for State effects
 runState :: Eff (State s ': e) b -> s -> Eff e (b, s)
 runState (Val b) s = pure (b, s)
-runState (E u q) s = case decomp u of
+runState (E u q) s = case decompose u of
   Right Get      -> runState (apply q s) s
   Right (Put s') -> runState (apply q ()) s'
   Left  u'       -> E u' (tsingleton (\a -> runState (apply q a) s))

--- a/src/Control/Monad/Effect/StateRW.hs
+++ b/src/Control/Monad/Effect/StateRW.hs
@@ -38,9 +38,9 @@ runStateR m s = loop s m
  where
    loop :: s -> Eff (Writer s ': Reader s ': e) a -> Eff e (a, s)
    loop s' (Val x) = pure (x,s')
-   loop s' (E u q) = case decomp u of
+   loop s' (E u q) = case decompose u of
      Right (Writer o) -> k o ()
-     Left  u'  -> case decomp u' of
+     Left  u'  -> case decompose u' of
        Right Reader -> k s' s'
        Left u'' -> E u'' (tsingleton (k s'))
     where k s'' = q >>> (loop s'')

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -38,6 +38,6 @@ trace = send . Trace
 -- | An IO handler for Trace effects
 runTrace :: Eff '[Trace] a -> IO a
 runTrace (Val x) = return x
-runTrace (E u q) = case decomp u of
+runTrace (E u q) = case decompose u of
      Right (Trace s) -> putStrLn s >> runTrace (apply q ())
      Left _          -> error "runTrace:Left - This should never happen"

--- a/src/Control/Monad/Effect/Writer.hs
+++ b/src/Control/Monad/Effect/Writer.hs
@@ -5,7 +5,7 @@
 
 {-|
 Module      : Control.Monad.Effect.Writer
-Description : Composable Writer effects -
+Description : Composable Writer effects
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -2,7 +2,7 @@
 
 {-|
 Module      : Data.FTCQueue
-Description : Fast type-aligned queue optimized to effectful functions.
+Description : Fast type-aligned concatable queue optimized to effectful functions.
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
 Maintainer  : cpp.cabrera@gmail.com

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -39,30 +39,30 @@ data FTCQueue m a b where
   Leaf :: (a -> m b) -> FTCQueue m a b
   Node :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
 
-{-# INLINE tsingleton #-}
 -- | Build a leaf from a single operation [O(1)]
 tsingleton :: (a -> m b) -> FTCQueue m a b
 tsingleton = Leaf
+{-# INLINE tsingleton #-}
 
-{-# INLINE (|>) #-}
 -- | Append an operation to the right of the tree [O(1)]
 (|>) :: FTCQueue m a x -> (x -> m b) -> FTCQueue m a b
 t |> r = Node t (Leaf r)
+{-# INLINE (|>) #-}
 
-{-# INLINE snoc #-}
 -- | An alias for '(|>)'
 snoc :: FTCQueue m a x -> (x -> m b) -> FTCQueue m a b
 snoc = (|>)
+{-# INLINE snoc #-}
 
-{-# INLINE (><) #-}
 -- | Append two trees of operations [O(1)]
 (><)   :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
 t1 >< t2 = Node t1 t2
+{-# INLINE (><) #-}
 
-{-# INLINE append #-}
 -- | An alias for '(><)'
 append :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
 append = (><)
+{-# INLINE append #-}
 
 -- | Left view deconstruction data structure
 data ViewL m a b where

--- a/src/Data/Open/Union.hs
+++ b/src/Data/Open/Union.hs
@@ -38,7 +38,7 @@ The data constructors of Union are not exported.
 
 module Data.Open.Union (
   Union,
-  decomp,
+  decompose,
   weaken,
   inj,
   prj,
@@ -98,18 +98,18 @@ instance (FindElem t r) => t :< r where
   prj = prj' (unP (elemNo :: P t r))
 
 
-decomp :: Union (t ': r) v -> Either (Union r v) (t v)
-decomp (Union 0 v) = Right $ unsafeCoerce v
-decomp (Union n v) = Left  $ Union (n-1) v
-{-# INLINE [2] decomp #-}
+decompose :: Union (t ': r) v -> Either (Union r v) (t v)
+decompose (Union 0 v) = Right $ unsafeCoerce v
+decompose (Union n v) = Left  $ Union (n-1) v
+{-# INLINE [2] decompose #-}
 
 
--- | Specialized version of 'decomp'.
-decomp0 :: Union '[t] v -> Either (Union '[] v) (t v)
-decomp0 (Union _ v) = Right $ unsafeCoerce v
+-- | Specialized version of 'decompose'.
+decompose0 :: Union '[t] v -> Either (Union '[] v) (t v)
+decompose0 (Union _ v) = Right $ unsafeCoerce v
 -- No other case is possible
-{-# RULES "decomp/singleton"  decomp = decomp0 #-}
-{-# INLINE decomp0 #-}
+{-# RULES "decompose/singleton"  decompose = decompose0 #-}
+{-# INLINE decompose0 #-}
 
 weaken :: Union r w -> Union (any ': r) w
 weaken (Union n v) = Union (n+1) v

--- a/src/Data/Open/Union.hs
+++ b/src/Data/Open/Union.hs
@@ -20,7 +20,7 @@ Portability : POSIX
 
 All operations are constant-time, and there is no Typeable constraint
 
-This is a variation of OpenUion5.hs, which relies on overlapping
+This is a variation of OpenUnion5.hs, which relies on overlapping
 instances instead of closed type families. Closed type families
 have their problems: overlapping instances can resolve even
 for unground types, but closed type families are subject to a
@@ -74,7 +74,7 @@ prj' :: Int -> Union r v -> Maybe (t v)
 prj' n (Union n' x) | n == n'   = Just (unsafeCoerce x)
                     | otherwise = Nothing
 
-newtype P t r = P{unP :: Int}
+newtype P t r = P { unP :: Int }
 
 infixr 5 :<:
 -- | Find a list of members 'm' in an open union 'r'.
@@ -114,9 +114,8 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 weaken :: Union r w -> Union (any ': r) w
 weaken (Union n v) = Union (n+1) v
 
--- Find an index of an element in a `list'
--- The element must exist
--- This is essentially a compile-time computation.
+-- Find an index of an element in an `r'.
+-- The element must exist, so this is essentially a compile-time computation.
 class FindElem (t :: * -> *) r where
   elemNo :: P t r
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE FunctionalDependencies, UndecidableInstances #-}
 
 {-|
-Module      : Data.Open.Union
+Module      : Data.Union
 Description : Open unions (type-indexed co-products) for extensible effects.
 Copyright   : Alej Cabrera 2015
 License     : BSD-3
@@ -36,7 +36,7 @@ universe.
 The data constructors of Union are not exported.
 -}
 
-module Data.Open.Union (
+module Data.Union (
   Union,
   decompose,
   weaken,

--- a/tests/Tests/Exception.hs
+++ b/tests/Tests/Exception.hs
@@ -25,7 +25,7 @@ import Tests.Common
 
 testExceptionTakesPriority :: Int -> Int -> Either Int Int
 testExceptionTakesPriority x y = run $ runError (go x y)
-  where go a b = return a `add` throwError b
+  where go a b = pure a `add` throwError b
 
 -- The following won't type: unhandled exception!
 -- ex2rw = run et2
@@ -50,7 +50,7 @@ ter2 :: Either String (String, Int)
 ter2 = run $ runError (runState tes1 (1::Int))
 
 teCatch :: (Exc String :< r) => Eff r a -> Eff r String
-teCatch m = catchError (m >> return "done") (\e -> return (e::String))
+teCatch m = catchError (m >> pure "done") (\e -> pure (e::String))
 
 ter3 :: (Either String String, Int)
 ter3 = run $ runState (runError (teCatch tes1)) (1::Int)
@@ -65,7 +65,7 @@ ex2 :: (Exc TooBig :< r) => Eff r Int -> Eff r Int
 ex2 m = do
   v <- m
   if v > 5 then throwError (TooBig v)
-     else return v
+     else pure v
 
 -- specialization to tell the type of the exception
 runErrBig :: Eff (Exc TooBig ': r) a -> Eff r (Either TooBig a)


### PR DESCRIPTION
Renames the following function:

- `decomp` to `decompose`
- `Arrows` to `Queue`
- Moves `Data.Open.Union` to `Data.Union`.