### PR TITLE
Make <*> lazy in its second argument where possible.

### DIFF
--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -169,7 +169,6 @@ instance Applicative (Eff e) where
 
   Val f <*> Val x = Val $ f x
   Val f <*> E u q = E u (q |> (Val . f))
-  E u q <*> Val x = E u (q |> (Val . ($ x)))
   E u q <*> m     = E u (q |> (`fmap` m))
   {-# INLINE (<*>) #-}
 


### PR DESCRIPTION
On `master`, use of `Control.Monad.forever` diverges. `forever` is defined as:

```haskell
forever a = let a' = a *> a' in a'
```

This definition of `forever` does not diverge:

```haskell
forever a = let a' = a >> a' in a'
```

It appears that `<*>` is a little too strict in its second argument. This PR resolves that by not forcing the evaluation of the second argument unless the first argument is in `Val`.

This should bring `Eff` into better semantic alignment with the `Applicative`/`Monad` relations:

> Furthermore, the Monad and Applicative operations should relate as follows:
> 
>     pure = return
>     (<*>) = ap
> 
> The above laws imply:
> 
>     fmap f xs  =  xs >>= return . f
>     (>>) = (*>)