### PR TITLE
Fix redundant constraints, improve instances, export Apply{0,1}

### DIFF
--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -199,8 +199,7 @@ instance Apply0 Show fs a => Show (Union fs a) where
   showsPrec d u = apply0 (Proxy :: Proxy Show) (showsPrec d) u
 
 instance Apply1 Eq1 fs => Eq1 (Union fs) where
-  liftEq eq u1@(Union n1 _) (Union n2 r2) | n1 == n2  = apply1 (Proxy :: Proxy Eq1) (flip (liftEq eq) (unsafeCoerce r2)) u1
-                                          | otherwise = False
+  liftEq eq u1 u2 = fromMaybe False (apply1_2 (Proxy :: Proxy Eq1) (liftEq eq) u1 u2)
 
 
 instance Apply1 Show1 fs => Show1 (Union fs) where

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -172,9 +172,7 @@ instance Apply1 Functor fs => Functor (Union fs) where
   fmap f (Union n r) = apply1 (Proxy :: Proxy Functor) (Proxy :: Proxy fs) n (Union n . fmap f) r
 
 instance (Apply1 Foldable fs, Apply1 Functor fs, Apply1 Traversable fs) => Traversable (Union fs) where
-  traverse f (Union n r) = Union n <$> apply1 (Proxy :: Proxy Traversable) (Proxy :: Proxy fs) n (withTypeOf f r . unsafeCoerce . traverse f) r
-    where withTypeOf :: (a -> f b) -> t a -> f (t b) -> f (t b)
-          withTypeOf _ _ = id
+  traverse f (Union n r) = apply1 (Proxy :: Proxy Traversable) (Proxy :: Proxy fs) n (fmap (Union n) . traverse f) r
 
 instance Apply0 Eq fs a => Eq (Union fs a) where
   Union n1 r1 == Union n2 r2 | n1 == n2  = apply0 (Proxy :: Proxy Eq) (Proxy :: Proxy fs) n1 (== unsafeCoerce r2) r1

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -136,6 +136,8 @@ instance {-# OVERLAPPING #-} t :< r => t :< (t' ': r) where
 class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
   apply0 :: proxy c -> (forall g . c (g a) => g a -> b) -> Union fs a -> b
 
+  apply0_2 :: proxy c -> (forall g . c (g a) => g a -> g a -> b) -> Union fs a -> Union fs a -> Maybe b
+
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1 :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
 
@@ -151,8 +153,13 @@ instance (c (f a), Apply0 c fs a) => Apply0 c (f ': fs) a where
   apply0 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)
                                | otherwise = apply0 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
 
+  apply0_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
+                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f a))
+                                                     | otherwise = apply0_2 proxy f (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
 instance Apply0 c '[] a where
-  apply0 _ _ _ = error "apply over empty Union"
+  apply0 _ _ _ = error "apply0 over empty Union"
+  apply0_2 _ _ _ _ = error "apply0_2 over empty Union"
 
 type family EQU (a :: k) (b :: k) :: Bool where
   EQU a a = 'True

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -151,10 +151,7 @@ instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
   apply1' proxy f u@(Union n r) | n == 0    = f (Union n) (unsafeCoerce r :: f a)
                                 | otherwise = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
 
-  apply1_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
-                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
-                                                     | otherwise = apply1_2 proxy f (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
-
+  apply1_2 proxy f = apply1_2' proxy (const f)
   apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
                                                       | n1 == 0   = Just (f (Union n1) (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
                                                       | otherwise = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -153,9 +153,9 @@ class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1_2' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 instance (c f0) => Apply1 c '[f0] where
-  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' _ f (Union _ r) = f (Union 0) (unsafeCoerce r :: f0 a)
 
-  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' _ f (Union _ r1) (Union _ r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
 
 instance (c f0, c f1) => Apply1 c '[f0, f1] where
   apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -141,15 +141,12 @@ class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
 
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1 :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
-
   apply1' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
 
   apply1_2 :: proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
-  apply1 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)
-                               | otherwise = apply1 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
-
+  apply1 proxy f = apply1' proxy (const f)
   apply1' proxy f u@(Union n r) | n == 0    = f (Union n) (unsafeCoerce r :: f a)
                                 | otherwise = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -137,19 +137,19 @@ instance {-# OVERLAPPING #-} t :< r => t :< (t' ': r) where
 class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
   apply0 :: proxy c -> (forall g . c (g a) => g a -> b) -> Union fs a -> b
 
-  apply0_2 :: proxy c -> (forall g . c (g a) => g a -> g a -> b) -> Union fs a -> Union fs a -> Maybe b
+  apply0_2 :: proxy c -> (forall g . c (g a) => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1 :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
 
-  apply1_2 :: proxy c -> (forall g . c g => g a -> g a -> b) -> Union fs a -> Union fs a -> Maybe b
+  apply1_2 :: proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
   apply1 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)
                                | otherwise = apply1 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
 
   apply1_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
-                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f a))
+                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
                                                      | otherwise = apply1_2 proxy f (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
 
 instance Apply1 c '[] where
@@ -161,7 +161,7 @@ instance (c (f a), Apply0 c fs a) => Apply0 c (f ': fs) a where
                                | otherwise = apply0 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
 
   apply0_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
-                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f a))
+                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
                                                      | otherwise = apply0_2 proxy f (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
 
 instance Apply0 c '[] a where

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -193,7 +193,7 @@ instance Apply1 Foldable fs => Foldable (Union fs) where
   foldMap f u = apply1 (Proxy :: Proxy Foldable) (foldMap f) u
 
 instance Apply1 Functor fs => Functor (Union fs) where
-  fmap f u@(Union n _) = apply1 (Proxy :: Proxy Functor) (Union n . fmap f) u
+  fmap f u = apply1' (Proxy :: Proxy Functor) ((. fmap f)) u
 
 instance (Apply1 Foldable fs, Apply1 Functor fs, Apply1 Traversable fs) => Traversable (Union fs) where
   traverse f u@(Union n _) = apply1 (Proxy :: Proxy Traversable) (fmap (Union n) . traverse f) u

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -169,9 +169,7 @@ instance Apply1 Foldable fs => Foldable (Union fs) where
   foldMap f (Union n r) = apply1 (Proxy :: Proxy Foldable) (Proxy :: Proxy fs) n (foldMap f) r
 
 instance Apply1 Functor fs => Functor (Union fs) where
-  fmap f (Union n r) = Union n (apply1 (Proxy :: Proxy Functor) (Proxy :: Proxy fs) n (withTypeOf f r . unsafeCoerce . fmap f) r)
-    where withTypeOf :: (a -> b) -> t a -> t b -> t b
-          withTypeOf _ _ = id
+  fmap f (Union n r) = apply1 (Proxy :: Proxy Functor) (Proxy :: Proxy fs) n (Union n . fmap f) r
 
 instance (Apply1 Foldable fs, Apply1 Functor fs, Apply1 Traversable fs) => Traversable (Union fs) where
   traverse f (Union n r) = Union n <$> apply1 (Proxy :: Proxy Traversable) (Proxy :: Proxy fs) n (withTypeOf f r . unsafeCoerce . traverse f) r

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -152,17 +152,360 @@ class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
 
   apply1_2' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
-instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
-  apply1' proxy f u@(Union n r) | n == 0    = f (Union n) (unsafeCoerce r :: f a)
-                                | otherwise = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+instance (c f0) => Apply1 c '[f0] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
 
-  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
-                                                      | n1 == 0   = Just (f (Union n1) (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
-                                                      | otherwise = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
 
-instance Apply1 c '[] where
-  apply1' _ _ _ = error "apply1' over empty Union"
-  apply1_2' _ _ _ _ = error "apply1_2 over empty Union"
+instance (c f0, c f1) => Apply1 c '[f0, f1] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2) => Apply1 c '[f0, f1, f2] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3) => Apply1 c '[f0, f1, f2, f3] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4) => Apply1 c '[f0, f1, f2, f3, f4] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5) => Apply1 c '[f0, f1, f2, f3, f4, f5] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45, c f46) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45, c f46, c f47) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45, c f46, c f47, c f48) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45, c f46, c f47, c f48, c f49) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48, f49] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f11, c f12, c f13, c f14, c f15, c f16, c f17, c f18, c f19, c f20, c f21, c f22, c f23, c f24, c f25, c f26, c f27, c f28, c f29, c f30, c f31, c f32, c f33, c f34, c f35, c f36, c f37, c f38, c f39, c f40, c f41, c f42, c f43, c f44, c f45, c f46, c f47, c f48, c f49, c f50) => Apply1 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48, f49, f50] where
+  apply1' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply1' proxy f u@(Union n r) = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
 
 instance (c (f a), Apply0 c fs a) => Apply0 c (f ': fs) a where
   apply0 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -51,6 +51,7 @@ module Data.Union (
 ) where
 
 import Data.Functor.Classes (Eq1(..), Show1(..))
+import Data.Maybe (fromMaybe)
 import Data.Proxy
 import Unsafe.Coerce(unsafeCoerce)
 import GHC.Exts (Constraint)
@@ -192,8 +193,7 @@ instance (Apply1 Foldable fs, Apply1 Functor fs, Apply1 Traversable fs) => Trave
   traverse f u@(Union n _) = apply1 (Proxy :: Proxy Traversable) (fmap (Union n) . traverse f) u
 
 instance Apply0 Eq fs a => Eq (Union fs a) where
-  u1@(Union n1 _) == Union n2 r2 | n1 == n2  = apply0 (Proxy :: Proxy Eq) (== unsafeCoerce r2) u1
-                                 | otherwise = False
+  u1 == u2 = fromMaybe False (apply0_2 (Proxy :: Proxy Eq) (==) u1 u2)
 
 instance Apply0 Show fs a => Show (Union fs a) where
   showsPrec d u = apply0 (Proxy :: Proxy Show) (showsPrec d) u

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -117,6 +117,9 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 weaken :: Union r w -> Union (any ': r) w
 weaken (Union n v) = Union (n+1) v
 
+asStrongerUnionTypeOf :: Union fs a -> Union (f ': fs) a -> Union fs a
+asStrongerUnionTypeOf = const
+
 -- Find an index of an element in an `r'.
 -- The element must exist, so this is essentially a compile-time computation.
 class (t :: * -> *) :< r where

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -142,11 +142,16 @@ class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1 :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
 
+  apply1' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
+
   apply1_2 :: proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
   apply1 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)
                                | otherwise = apply1 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply1' proxy f u@(Union n r) | n == 0    = f (Union n) (unsafeCoerce r :: f a)
+                                | otherwise = apply1' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
 
   apply1_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
                                                      | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
@@ -154,6 +159,7 @@ instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
 
 instance Apply1 c '[] where
   apply1 _ _ _ = error "apply1 over empty Union"
+  apply1' _ _ _ = error "apply1' over empty Union"
   apply1_2 _ _ _ _ = error "apply1_2 over empty Union"
 
 instance (c (f a), Apply0 c fs a) => Apply0 c (f ': fs) a where

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -137,9 +137,371 @@ instance {-# OVERLAPPING #-} t :< r => t :< (t' ': r) where
 
 -- | Helper to apply a function to a functor of the nth type in a type list.
 class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
-  apply0 :: proxy c -> (forall g . c (g a) => g a -> b) -> Union fs a -> b
+  apply0' :: proxy c -> (forall g . c (g a) => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
 
-  apply0_2 :: proxy c -> (forall g . c (g a) => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
+  apply0_2' :: proxy c -> (forall g . c (g a) => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
+
+apply0 :: Apply0 c fs a => proxy c -> (forall g . c (g a) => g a -> b) -> Union fs a -> b
+apply0 proxy f = apply0' proxy (const f)
+
+apply0_2 :: Apply0 c fs a => proxy c -> (forall g . c (g a) => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
+apply0_2 proxy f = apply0_2' proxy (const f)
+
+instance (c (f0 a)) => Apply0 c '[f0] a where
+  apply0' _ f (Union _ r) = f (Union 0) (unsafeCoerce r :: f0 a)
+
+  apply0_2' _ f (Union _ r1) (Union _ r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+
+instance (c (f0 a), c (f1 a)) => Apply0 c '[f0, f1] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a)) => Apply0 c '[f0, f1, f2] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a)) => Apply0 c '[f0, f1, f2, f3] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a)) => Apply0 c '[f0, f1, f2, f3, f4] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a), c (f46 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a), c (f46 a), c (f47 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a), c (f46 a), c (f47 a), c (f48 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a), c (f46 a), c (f47 a), c (f48 a), c (f49 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48, f49] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
+instance (c (f0 a), c (f1 a), c (f2 a), c (f3 a), c (f4 a), c (f5 a), c (f6 a), c (f7 a), c (f8 a), c (f9 a), c (f10 a), c (f11 a), c (f12 a), c (f13 a), c (f14 a), c (f15 a), c (f16 a), c (f17 a), c (f18 a), c (f19 a), c (f20 a), c (f21 a), c (f22 a), c (f23 a), c (f24 a), c (f25 a), c (f26 a), c (f27 a), c (f28 a), c (f29 a), c (f30 a), c (f31 a), c (f32 a), c (f33 a), c (f34 a), c (f35 a), c (f36 a), c (f37 a), c (f38 a), c (f39 a), c (f40 a), c (f41 a), c (f42 a), c (f43 a), c (f44 a), c (f45 a), c (f46 a), c (f47 a), c (f48 a), c (f49 a), c (f50 a)) => Apply0 c '[f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30, f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44, f45, f46, f47, f48, f49, f50] a where
+  apply0' _ f (Union 0 r) = f (Union 0) (unsafeCoerce r :: f0 a)
+  apply0' proxy f u@(Union n r) = apply0' proxy (\ toU -> f (weaken . toU)) (Union (pred n) r `asStrongerUnionTypeOf` u)
+
+  apply0_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
+  apply0_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply0_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
+
 
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
   apply1' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
@@ -506,18 +868,6 @@ instance (c f0, c f1, c f2, c f3, c f4, c f5, c f6, c f7, c f8, c f9, c f10, c f
 
   apply1_2' _ f (Union 0 r1) (Union 0 r2) = Just (f (Union 0) (unsafeCoerce r1 :: f0 a) (unsafeCoerce r2))
   apply1_2' proxy f u1@(Union n1 r1) u2@(Union n2 r2) = apply1_2' proxy (\ toU -> f (weaken . toU)) (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
-
-instance (c (f a), Apply0 c fs a) => Apply0 c (f ': fs) a where
-  apply0 proxy f u@(Union n r) | n == 0    = f (unsafeCoerce r :: f a)
-                               | otherwise = apply0 proxy f (Union (pred n) r `asStrongerUnionTypeOf` u)
-
-  apply0_2 proxy f u1@(Union n1 r1) u2@(Union n2 r2) | n1 /= n2  = Nothing
-                                                     | n1 == 0   = Just (f (unsafeCoerce r1 :: f a) (unsafeCoerce r2 :: f b))
-                                                     | otherwise = apply0_2 proxy f (Union (pred n1) r1 `asStrongerUnionTypeOf` u1) (Union (pred n2) r2 `asStrongerUnionTypeOf` u2)
-
-instance Apply0 c '[] a where
-  apply0 _ _ _ = error "apply0 over empty Union"
-  apply0_2 _ _ _ _ = error "apply0_2 over empty Union"
 
 type family EQU (a :: k) (b :: k) :: Bool where
   EQU a a = 'True

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -131,10 +131,10 @@ instance {-# OVERLAPPING #-} FindElem t r => FindElem t (t' ': r) where
 
 -- | Helper to apply a function to a functor of the nth type in a type list.
 class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
-  apply0 :: Proxy c -> Proxy fs -> Int -> (forall g . c (g a) => g a -> b) -> t a -> b
+  apply0 :: proxy1 c -> proxy2 fs -> Int -> (forall g . c (g a) => g a -> b) -> t a -> b
 
 class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
-  apply1 :: Proxy c -> Proxy fs -> Int -> (forall g . c g => g a -> b) -> t a -> b
+  apply1 :: proxy1 c -> proxy2 fs -> Int -> (forall g . c g => g a -> b) -> t a -> b
 
 instance (c f, Apply1 c fs) => Apply1 c (f ': fs) where
   apply1 proxy _ n f r | n == 0    = f (unsafeCoerce r :: f a)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -196,7 +196,7 @@ instance Apply1 Functor fs => Functor (Union fs) where
   fmap f u = apply1' (Proxy :: Proxy Functor) ((. fmap f)) u
 
 instance (Apply1 Foldable fs, Apply1 Functor fs, Apply1 Traversable fs) => Traversable (Union fs) where
-  traverse f u@(Union n _) = apply1 (Proxy :: Proxy Traversable) (fmap (Union n) . traverse f) u
+  traverse f u = apply1' (Proxy :: Proxy Traversable) ((. traverse f) . fmap) u
 
 instance Apply0 Eq fs a => Eq (Union fs a) where
   u1 == u2 = fromMaybe False (apply0_2 (Proxy :: Proxy Eq) (==) u1 u2)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -141,16 +141,16 @@ class Apply0 (c :: * -> Constraint) (fs :: [k -> *]) (a :: k) where
 
   apply0_2 :: proxy c -> (forall g . c (g a) => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
+class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
+  apply1' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
+
+  apply1_2' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
+
 apply1 :: Apply1 c fs => proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
 apply1 proxy f = apply1' proxy (const f)
 
 apply1_2 :: Apply1 c fs => proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 apply1_2 proxy f = apply1_2' proxy (const f)
-
-class Apply1 (c :: (k -> *) -> Constraint) (fs :: [k -> *]) where
-  apply1' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
-
-  apply1_2' :: proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 
 instance (c f0) => Apply1 c '[f0] where
   apply1' _ f (Union _ r) = f (Union 0) (unsafeCoerce r :: f0 a)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -45,7 +45,9 @@ module Data.Union (
   prj,
   type(:<),
   type(:<:),
-  MemberU2
+  MemberU2,
+  Apply0(..),
+  Apply1(..)
 ) where
 
 import Data.Functor.Classes (Eq1(..), Show1(..))


### PR DESCRIPTION
This PR:

- Fixes redundant constraint warnings in ghc 8.2.1. It does this by renaming `FindElem` to `:<`, removing the old `:<` class, and defining `inj` & `prj` as functions instead of methods. This was measured to ensure that it did not regress runtime performance.
- Cleans up `Apply0` & `Apply1` by taking the `Union` directly, instead of a proxy for the type list & the index.
- Cleans up all of the instances using the above.
- Exports `Apply0` & `Apply1` so that consumers can use them to improve compile times.
- Further cleans up the `Functor` & `Traversable` instances by removing the casting & coercion.
- Defines methods lifting binary functions into `Union`s.
- Cleans up the `Eq` & `Eq1` instances using the above.
- Adds an `apply1` variant whose function argument receives a `Union` constructor.
- Defines the `Functor` & `Traversable` instances using the above without any private knowledge of `Union`’s structure ✨
- Replaces the slow-to-compile inductive `Apply0` & `Apply1` instances with fast-to-compile flattened instances for 1-50 type parameters. This is terrible and I am not at all ashamed.