### PR TITLE
Inline apply

### DIFF
--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -179,6 +179,9 @@ instance Apply Functor fs => Functor (Union fs) where
   fmap f = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (fmap f a))
   {-# INLINABLE fmap #-}
 
+  (<$) v = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (v <$ a))
+  {-# INLINABLE (<$) #-}
+
 instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversable (Union fs) where
   traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> traverse f a)
   {-# INLINABLE traverse #-}

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -139,16 +139,19 @@ class Apply (c :: (* -> *) -> Constraint) (fs :: [* -> *]) where
 
 apply' :: Apply c fs => proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
 apply' proxy f u@(Union n _) = apply proxy (\ r -> f (Union n) r) u
+{-# INLINABLE apply' #-}
 
 apply2 :: Apply c fs => proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 apply2 proxy f u@(Union n1 _) (Union n2 r2)
   | n1 == n2  = Just (apply proxy (\ r1 -> f r1 (unsafeCoerce r2)) u)
   | otherwise = Nothing
+{-# INLINABLE apply2 #-}
 
 apply2' :: Apply c fs => proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
 apply2' proxy f u@(Union n1 _) (Union n2 r2)
   | n1 == n2  = Just (apply' proxy (\ reinj r1 -> f reinj r1 (unsafeCoerce r2)) u)
   | otherwise = Nothing
+{-# INLINABLE apply2' #-}
 
 pure (mkApplyInstance <$> [1..150])
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -172,15 +172,15 @@ instance (t :< (t' ': r), MemberU2 tag t r) =>
            MemberU' 'False tag t (t' ': r)
 
 instance Apply Foldable fs => Foldable (Union fs) where
-  foldMap f u = apply (Proxy :: Proxy Foldable) (foldMap f) u
+  foldMap f = apply (Proxy :: Proxy Foldable) (foldMap f)
   {-# INLINABLE foldMap #-}
 
 instance Apply Functor fs => Functor (Union fs) where
-  fmap f u = apply' (Proxy :: Proxy Functor) (\ reinj -> reinj . fmap f) u
+  fmap f = apply' (Proxy :: Proxy Functor) (\ reinj -> reinj . fmap f)
   {-# INLINABLE fmap #-}
 
 instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversable (Union fs) where
-  traverse f u = apply' (Proxy :: Proxy Traversable) (\ reinj -> fmap reinj . traverse f) u
+  traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj -> fmap reinj . traverse f)
   {-# INLINABLE traverse #-}
 
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -175,6 +175,18 @@ instance Apply Foldable fs => Foldable (Union fs) where
   foldMap f = apply (Proxy :: Proxy Foldable) (foldMap f)
   {-# INLINABLE foldMap #-}
 
+  foldr combine seed = apply (Proxy :: Proxy Foldable) (foldr combine seed)
+  {-# INLINABLE foldr #-}
+
+  foldl combine seed = apply (Proxy :: Proxy Foldable) (foldl combine seed)
+  {-# INLINABLE foldl #-}
+
+  null = apply (Proxy :: Proxy Foldable) null
+  {-# INLINABLE null #-}
+
+  length = apply (Proxy :: Proxy Foldable) length
+  {-# INLINABLE length #-}
+
 instance Apply Functor fs => Functor (Union fs) where
   fmap f = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (fmap f a))
   {-# INLINABLE fmap #-}

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -186,6 +186,9 @@ instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversa
   traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> traverse f a)
   {-# INLINABLE traverse #-}
 
+  sequenceA = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> sequenceA a)
+  {-# INLINABLE sequenceA #-}
+
 
 instance Apply Eq1 fs => Eq1 (Union fs) where
   liftEq eq u1 u2 = fromMaybe False (apply2 (Proxy :: Proxy Eq1) (liftEq eq) u1 u2)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -176,11 +176,11 @@ instance Apply Foldable fs => Foldable (Union fs) where
   {-# INLINABLE foldMap #-}
 
 instance Apply Functor fs => Functor (Union fs) where
-  fmap f = apply' (Proxy :: Proxy Functor) (\ reinj -> reinj . fmap f)
+  fmap f = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (fmap f a))
   {-# INLINABLE fmap #-}
 
 instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversable (Union fs) where
-  traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj -> fmap reinj . traverse f)
+  traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> traverse f a)
   {-# INLINABLE traverse #-}
 
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -173,30 +173,39 @@ instance (t :< (t' ': r), MemberU2 tag t r) =>
 
 instance Apply Foldable fs => Foldable (Union fs) where
   foldMap f u = apply (Proxy :: Proxy Foldable) (foldMap f) u
+  {-# INLINABLE foldMap #-}
 
 instance Apply Functor fs => Functor (Union fs) where
   fmap f u = apply' (Proxy :: Proxy Functor) (\ reinj -> reinj . fmap f) u
+  {-# INLINABLE fmap #-}
 
 instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversable (Union fs) where
   traverse f u = apply' (Proxy :: Proxy Traversable) (\ reinj -> fmap reinj . traverse f) u
+  {-# INLINABLE traverse #-}
 
 
 instance Apply Eq1 fs => Eq1 (Union fs) where
   liftEq eq u1 u2 = fromMaybe False (apply2 (Proxy :: Proxy Eq1) (liftEq eq) u1 u2)
+  {-# INLINABLE liftEq #-}
 
 instance (Apply Eq1 fs, Eq a) => Eq (Union fs a) where
   (==) = eq1
+  {-# INLINABLE (==) #-}
 
 
 instance (Apply Eq1 fs, Apply Ord1 fs) => Ord1 (Union fs) where
   liftCompare compareA u1@(Union n1 _) u2@(Union n2 _) = fromMaybe (compare n1 n2) (apply2 (Proxy :: Proxy Ord1) (liftCompare compareA) u1 u2)
+  {-# INLINABLE liftCompare #-}
 
 instance (Apply Eq1 fs, Apply Ord1 fs, Ord a) => Ord (Union fs a) where
   compare = compare1
+  {-# INLINABLE compare #-}
 
 
 instance Apply Show1 fs => Show1 (Union fs) where
-  liftShowsPrec sp sl d u = apply (Proxy :: Proxy Show1) (liftShowsPrec sp sl d) u
+  liftShowsPrec sp sl d = apply (Proxy :: Proxy Show1) (liftShowsPrec sp sl d)
+  {-# INLINABLE liftShowsPrec #-}
 
 instance (Apply Show1 fs, Show a) => Show (Union fs a) where
   showsPrec = showsPrec1
+  {-# INLINABLE showsPrec #-}

--- a/src/Data/Union/Templates.hs
+++ b/src/Data/Union/Templates.hs
@@ -18,7 +18,9 @@ mkElemIndexTypeFamily paramN =
 mkApplyInstance :: Integer -> Dec
 mkApplyInstance paramN =
   InstanceD Nothing (AppT constraint <$> typeParams) (AppT (AppT (ConT applyC) constraint) (typeListT PromotedNilT typeParams))
-    [ FunD apply (zipWith mkClause [0..] typeParams) ]
+    [ FunD apply (zipWith mkClause [0..] typeParams)
+    , PragmaD (InlineP apply Inlinable FunLike AllPhases)
+    ]
   where typeParams = VarT . mkName . ('f' :) . show <$> [0..pred paramN]
         [applyC, apply, f, r, union] = mkName <$> ["Apply", "apply", "f", "r", "Union"]
         [constraint, a] = VarT . mkName <$> ["constraint", "a"]


### PR DESCRIPTION
This PR marks `apply` & friends as `INLINABLE`, ensuring that their definitions are available in the interface file but still deferring the choice of whether to inline to the call site. It also does the same with the methods of `Functor` &c.

Finally, it defines a bunch of the other methods for `Foldable` &c., s.t. specialized definitions with optimized implementations of `length` (for example) will still use the optimized implementation when in a `Union`.