### PR TITLE
Export Member and Members constraints

### DIFF
--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -11,12 +11,15 @@ Portability : POSIX
 -}
 module Control.Monad.Effect (
   -- * Running and Sending Effects
-  Eff,
-  run,
-  send,
-  -- * Checking a List of Effects
-  type(:<),
-  type(:<:)
+  Eff
+  , run
+  , send
+  -- * Checking a List of Effects#
+  , type(:<)
+  , type(:<:)
+  , Member
+  , Members
+
 ) where
 
 import Control.Monad.Effect.Internal

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -13,31 +13,33 @@
 
 module Control.Monad.Effect.Internal (
   -- * Constructing and Sending Effects
-  Eff(..),
-  send,
+  Eff(..)
+  , send
   -- * Decomposing Unions
-  type(:<),
-  type(:<:),
+  , type(:<)
+  , type(:<:)
+  , Member
+  , Members
   -- | Inserts multiple effects into 'E'.
-  inj,
-  prj,
+  , inj
+  , prj
   -- * Constructing and Decomposing Queues of Effects
-  decompose,
-  Queue,
-  tsingleton,
-  Arrow,
-  Union,
+  , decompose
+  , Queue
+  , tsingleton
+  , Arrow
+  , Union
   -- * Composing and Applying Effects
-  apply,
-  (<<<),
-  (>>>),
+  , apply
+  , (<<<)
+  , (>>>)
   -- * Running Effects
-  run,
-  runM,
+  , run
+  , runM
   -- * Relaying and Interposing Effects
-  relay,
-  relayState,
-  interpose,
+  , relay
+  , relayState
+  , interpose
 ) where
 
 import Data.Union hiding (apply)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -46,6 +46,8 @@ module Data.Union (
   prj,
   type(:<),
   type(:<:),
+  Member,
+  Members,
   MemberU2,
   Apply(..),
   apply',

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -85,10 +85,12 @@ prj' n (Union n' x) | n == n'   = Just (unsafeCoerce x)
 newtype P (t :: * -> *) (r :: [* -> *]) = P { unP :: Int }
 
 infixr 5 :<:
--- | Find a list of members 'm' in an open union 'r'.
-type family m :<: r :: Constraint where
-  (t ': c) :<: r = (t :< r, c :<: r)
-  '[] :<: r = ()
+-- | Find a list of members 'ms' in an open union 'r'.
+type family Members ms r :: Constraint where
+  Members (t ': cs) r = (Member t r, Members cs r)
+  Members '[] r = ()
+
+type (ts :<: r) = Members ts r
 
 {-
 -- Optimized specialized instance
@@ -126,7 +128,8 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 weaken :: Union r w -> Union (any ': r) w
 weaken (Union n v) = Union (n+1) v
 
-type (t :< r) = KnownNat (ElemIndex t r)
+type (Member t r) = KnownNat (ElemIndex t r)
+type (t :< r) = Member t r
 
 -- Find an index of an element in an `r'.
 -- The element must exist, so this is essentially a compile-time computation.


### PR DESCRIPTION
It's sometimes annoying to include the `TypeOperators` extension just to use effects, so let's export `Member` and `Members`.