### PR TITLE
Composite interpreters

### DIFF
--- a/effects.cabal
+++ b/effects.cabal
@@ -46,6 +46,7 @@ library
                      , Control.Monad.Effect.NonDet
                      , Control.Monad.Effect.Reader
                      , Control.Monad.Effect.Resumable
+                     , Control.Monad.Effect.Run
                      , Control.Monad.Effect.State
                      , Control.Monad.Effect.StateRW
                      , Control.Monad.Effect.TH

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -19,6 +19,7 @@ module Control.Monad.Effect (
   , relay
   , relayState
   , interpose
+  , interpret
   -- * Checking a List of Effects#
   , type(:<)
   , type(:<:)

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -13,7 +13,12 @@ module Control.Monad.Effect (
   -- * Running and Sending Effects
   Eff
   , run
+  , runM
   , send
+  -- * Handling Effects
+  , relay
+  , relayState
+  , interpose
   -- * Checking a List of Effects#
   , type(:<)
   , type(:<:)
@@ -42,4 +47,3 @@ import Control.Monad.Effect.Resumable (Resumable, SomeExc(..))
 import Control.Monad.Effect.State (State)
 import Control.Monad.Effect.Trace (Trace)
 import Control.Monad.Effect.Writer (Writer)
-

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -15,7 +15,6 @@ module Control.Monad.Effect (
   , run
   , runM
   , send
-  , sendM
   -- * Handling Effects
   , relay
   , relayState

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -15,6 +15,7 @@ module Control.Monad.Effect (
   , run
   , runM
   , send
+  , sendM
   -- * Handling Effects
   , relay
   , relayState

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -41,11 +41,12 @@ yield x f = send (Yield x f)
 -- |
 -- Status of a thread: done or reporting the value of the type a and
 -- resuming with the value of type b
-data Status e a b = Done | Continue a (b -> Eff e (Status e a b))
+data Status e a b w = Done w | Continue a (b -> Eff e (Status e a b w))
+  deriving (Functor)
 
 -- | Launch a thread and report its status
-runC :: Eff (Yield a b ': e) w -> Eff e (Status e a b)
-runC = relay (\_ -> pure Done) bind
+runC :: Eff (Yield a b ': e) w -> Eff e (Status e a b w)
+runC = relay (pure . Done) bind
   where
-    bind :: Yield a b v -> Arrow e v (Status e a b) -> Eff e (Status e a b)
+    bind :: Yield a b v -> Arrow e v (Status e a b w) -> Eff e (Status e a b w)
     bind (Yield a k) arr = pure $ Continue a (arr . k)

--- a/src/Control/Monad/Effect/Cut.hs
+++ b/src/Control/Monad/Effect/Cut.hs
@@ -38,7 +38,7 @@ cutFalse = throwError CutFalse
 {-
 call :: (Exc CutFalse :< r) => Eff (Exc CutFalse ': r) a -> Eff r a
 call m = loop [] m where
- loop jq (Val x) = return x `mplus` next jq          -- (C2)
+ loop jq (Val x) = pure x `mplus` next jq          -- (C2)
  loop jq (E u q) = case decompose u of
     Right (Exc CutFalse) -> mzero  -- drop jq (F2)
     Left u -> check jq u

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -194,6 +194,7 @@ instance Monad (Eff e) where
 
 instance Member IO e => MonadIO (Eff e) where
   liftIO = send
+  {-# INLINE liftIO #-}
 
 
 -- | A data type for representing nondeterminstic choice

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -109,7 +109,7 @@ run _       = error "Internal:run - This (E) should never happen"
 runM :: Monad m => Eff '[m] a -> m a
 runM (Val x) = pure x
 runM (E u q) = case decompose u of
-  Right m -> m >>= runM . (apply q)
+  Right m -> m >>= runM . apply q
   Left _   -> error "Internal:runM - This (Left) should never happen"
 
 -- | Given an effect request, either handle it with the given 'pure' function,

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -41,6 +41,7 @@ module Control.Monad.Effect.Internal (
   , relay
   , relayState
   , interpose
+  , interpret
 ) where
 
 import Control.Applicative (Alternative(..))
@@ -160,6 +161,11 @@ interpose ret h = loop
      Just x -> h x k
      _      -> E u (tsingleton k)
     where k = q >>> loop
+
+-- | Handle the topmost effect by interpreting it into the underlying effects.
+interpret :: (forall a. eff a -> Eff effs a) -> Eff (eff ': effs) b -> Eff effs b
+interpret f = relay pure (\ eff yield -> f eff >>= yield)
+
 
 -- * Effect Instances
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -15,7 +15,6 @@ module Control.Monad.Effect.Internal (
   -- * Constructing and Sending Effects
   Eff(..)
   , send
-  , sendM
   , NonDet(..)
   -- * Decomposing Unions
   , type(:<)
@@ -92,10 +91,6 @@ apply q' x =
 -- | Send a effect and wait for a reply.
 send :: (eff :< e) => eff b -> Eff e b
 send t = E (inj t) (tsingleton Val)
-
--- | A type-restricted variant of 'send' useful for embedding 'Monad'ic computations as the last element of an 'Eff' computation.
-sendM :: LastMember m effects => m a -> Eff effects a
-sendM = send
 
 -- | Runs an effect whose effects has been consumed.
 --

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- The following is needed to define MonadPlus instance. It is decidable
 -- (there is no recursion!), but GHC cannot see that.
@@ -49,7 +47,6 @@ module Control.Monad.Effect.Internal (
 
 import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus(..))
-import Control.Monad.IO.Class (MonadIO(..))
 import Data.Union hiding (apply)
 import Data.FTCQueue
 
@@ -198,10 +195,6 @@ instance Monad (Eff e) where
   Val x >>= k = k x
   E u q >>= k = E u (q |> k)
   {-# INLINE (>>=) #-}
-
-
-instance (MonadIO io, LastMember io effs) => MonadIO (Eff effs) where
-  liftIO = sendM @io . liftIO
 
 
 -- | A data type for representing nondeterminstic choice

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -46,6 +46,7 @@ module Control.Monad.Effect.Internal (
 
 import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus(..))
+import Control.Monad.IO.Class (MonadIO(..))
 import Data.Union hiding (apply)
 import Data.FTCQueue
 
@@ -190,6 +191,9 @@ instance Monad (Eff e) where
   Val x >>= k = k x
   E u q >>= k = E u (q |> k)
   {-# INLINE (>>=) #-}
+
+instance Member IO e => MonadIO (Eff e) where
+  liftIO = send
 
 
 -- | A data type for representing nondeterminstic choice

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- The following is needed to define MonadPlus instance. It is decidable
 -- (there is no recursion!), but GHC cannot see that.
@@ -47,6 +49,7 @@ module Control.Monad.Effect.Internal (
 
 import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus(..))
+import Control.Monad.IO.Class (MonadIO(..))
 import Data.Union hiding (apply)
 import Data.FTCQueue
 
@@ -195,6 +198,10 @@ instance Monad (Eff e) where
   Val x >>= k = k x
   E u q >>= k = E u (q |> k)
   {-# INLINE (>>=) #-}
+
+
+instance (MonadIO io, LastMember io effs) => MonadIO (Eff effs) where
+  liftIO = sendM @io . liftIO
 
 
 -- | A data type for representing nondeterminstic choice

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -15,6 +15,7 @@ module Control.Monad.Effect.Internal (
   -- * Constructing and Sending Effects
   Eff(..)
   , send
+  , sendM
   , NonDet(..)
   -- * Decomposing Unions
   , type(:<)
@@ -91,6 +92,10 @@ apply q' x =
 -- | Send a effect and wait for a reply.
 send :: (eff :< e) => eff b -> Eff e b
 send t = E (inj t) (tsingleton Val)
+
+-- | A type-restricted variant of 'send' useful for embedding 'Monad'ic computations as the last element of an 'Eff' computation.
+sendM :: LastMember m effects => m a -> Eff effects a
+sendM = send
 
 -- | Runs an effect whose effects has been consumed.
 --

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -15,6 +15,7 @@ module Control.Monad.Effect.Internal (
   -- * Constructing and Sending Effects
   Eff(..)
   , send
+  , NonDet(..)
   -- * Decomposing Unions
   , type(:<)
   , type(:<:)
@@ -40,7 +41,6 @@ module Control.Monad.Effect.Internal (
   , relay
   , relayState
   , interpose
-  , NonDet(..)
 ) where
 
 import Control.Applicative (Alternative(..))

--- a/src/Control/Monad/Effect/NonDet.hs
+++ b/src/Control/Monad/Effect/NonDet.hs
@@ -26,18 +26,6 @@ import Control.Monad.Effect.Internal
 --------------------------------------------------------------------------------
                     -- Nondeterministic Choice --
 --------------------------------------------------------------------------------
--- | A data type for representing nondeterminstic choice
-data NonDet a where
-  MZero :: NonDet a
-  MPlus :: NonDet Bool
-
-instance (NonDet :< e) => Alternative (Eff e) where
-  empty = mzero
-  (<|>) = mplus
-
-instance (NonDet :< a) => MonadPlus (Eff a) where
-  mzero       = send MZero
-  mplus m1 m2 = send MPlus >>= \x -> if x then m1 else m2
 
 runNonDet :: Monoid b => (a -> b) -> Eff (NonDet ': e) a -> Eff e b
 runNonDet f = relay (pure . f) (\ m k -> case m of

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -51,7 +51,7 @@ asks f = f <$> ask
 
 -- | Handler for reader effects
 runReader :: Eff (Reader v ': e) a -> v -> Eff e a
-runReader m e = relay pure (\Reader k -> k e) m
+runReader m e = interpret (\ Reader -> pure e) m
 
 -- |
 -- Locally rebind the value in the dynamic environment

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -50,5 +50,8 @@ instance Run '[Trace] result (IO result) where
 instance (Monoid w, Run effects (result, w) rest) => Run (Writer w ': effects) result rest where
   run' = run' . runWriter
 
+instance Run '[IO] result (IO result) where
+  run' = runM
+
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -15,6 +15,8 @@ import Control.Monad.Effect.Trace
 import Control.Monad.Effect.Writer
 
 -- | Elimination of effects.
+--
+--   Instances provide interpreters, optionally taking arguments and optionally modifying the result type.
 class Run effects result function | effects result -> function where
   run :: Eff.Eff effects result -> function
 

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -5,6 +5,7 @@ import Control.Monad.Effect.Coroutine
 import Control.Monad.Effect.Embedded
 import Control.Monad.Effect.Exception
 import Control.Monad.Effect.Fail
+import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
@@ -21,6 +22,9 @@ instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result
 
 instance Run effects (Either String result) rest => Run (Fail ': effects) result rest where
   run' = run' . runFail
+
+instance Run effects result rest => Run (Fresh ': effects) result (Int -> rest) where
+  run' = fmap run' . runFresh'
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -12,6 +12,7 @@ import Control.Monad.Effect.Reader
 import Control.Monad.Effect.Resumable as Resumable
 import Control.Monad.Effect.State
 import Control.Monad.Effect.Trace
+import Control.Monad.Effect.Writer
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -45,6 +46,9 @@ instance Run effects (result, b) rest => Run (State b ': effects) result (b -> r
 
 instance Run '[Trace] result (IO result) where
   run' = runTrace
+
+instance (Monoid w, Run effects (result, w) rest) => Run (Writer w ': effects) result rest where
+  run' = run' . runWriter
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -18,6 +18,7 @@ import Control.Monad.Effect.Writer
 --
 --   Instances provide interpreters, optionally taking arguments and optionally modifying the result type.
 class Run effects result function | effects result -> function where
+  -- | Interpret the effects in the given computation, possibly taking some arguments, and return the result.
   run :: Eff.Eff effects result -> function
 
 

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, TypeOperators, UndecidableInstances #-}
 module Control.Monad.Effect.Run where
 
 import Control.Monad.Effect.Coroutine
+import Control.Monad.Effect.Embedded
 import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
@@ -9,6 +10,9 @@ class Run effects result function | effects result -> function where
 
 instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) -> rest) where
   run' = fmap run' . runCoro
+
+instance Run effects result rest => Run (Embedded effects ': effects) result rest where
+  run' = run' . relay pure (\ (Embed e) k -> e >>= k)
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -1,0 +1,1 @@
+module Control.Monad.Effect.Run where

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -4,6 +4,7 @@ module Control.Monad.Effect.Run where
 import Control.Monad.Effect.Coroutine
 import Control.Monad.Effect.Embedded
 import Control.Monad.Effect.Exception
+import Control.Monad.Effect.Fail
 import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
@@ -17,6 +18,9 @@ instance Run effects result rest => Run (Embedded effects ': effects) result res
 
 instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result rest where
   run' = run' . runError
+
+instance Run effects (Either String result) rest => Run (Fail ': effects) result rest where
+  run' = run' . runFail
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -3,6 +3,7 @@ module Control.Monad.Effect.Run where
 
 import Control.Monad.Effect.Coroutine
 import Control.Monad.Effect.Embedded
+import Control.Monad.Effect.Exception
 import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
@@ -13,6 +14,9 @@ instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) 
 
 instance Run effects result rest => Run (Embedded effects ': effects) result rest where
   run' = run' . relay pure (\ (Embed e) k -> e >>= k)
+
+instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result rest where
+  run' = run' . runError
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -5,3 +5,6 @@ import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
+
+instance Run '[] result result where
+  run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -17,6 +17,17 @@ import Control.Monad.Effect.Writer
 -- | Elimination of effects.
 --
 --   Instances provide interpreters, optionally taking arguments and optionally modifying the result type.
+--
+--   For example:
+--
+--   @
+--   run (eff :: Eff '[Reader Int, Fail, State String] ())
+--     1 -- to run the Reader effect
+--     "hello" -- to run the State effect
+--     :: ( Either String () -- the result of the Fail effect, wrapping the final result value
+--        , String ) -- the final state from the State effect
+--   @
+
 class Run effects result function | effects result -> function where
   -- | Interpret the effects in the given computation, possibly taking some arguments, and return the result.
   run :: Eff.Eff effects result -> function

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -7,6 +7,7 @@ import Control.Monad.Effect.Exception
 import Control.Monad.Effect.Fail
 import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal as Eff
+import Control.Monad.Effect.NonDet
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -25,6 +26,9 @@ instance Run effects (Either String result) rest => Run (Fail ': effects) result
 
 instance Run effects result rest => Run (Fresh ': effects) result (Int -> rest) where
   run' = fmap run' . runFresh'
+
+instance (Run effects [result] rest) => Run (NonDet ': effects) result rest where
+  run' = run' . runNonDet (:[])
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -3,12 +3,13 @@ module Control.Monad.Effect.Run where
 
 import Control.Monad.Effect.Coroutine
 import Control.Monad.Effect.Embedded
-import Control.Monad.Effect.Exception
+import Control.Monad.Effect.Exception as Exc
 import Control.Monad.Effect.Fail
 import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal as Eff
 import Control.Monad.Effect.NonDet
 import Control.Monad.Effect.Reader
+import Control.Monad.Effect.Resumable as Resumable
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -20,7 +21,7 @@ instance Run effects result rest => Run (Embedded effects ': effects) result res
   run' = run' . relay pure (\ (Embed e) k -> e >>= k)
 
 instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result rest where
-  run' = run' . runError
+  run' = run' . Exc.runError
 
 instance Run effects (Either String result) rest => Run (Fail ': effects) result rest where
   run' = run' . runFail
@@ -33,6 +34,9 @@ instance (Run effects [result] rest) => Run (NonDet ': effects) result rest wher
 
 instance Run effects result rest => Run (Reader b ': effects) result (b -> rest) where
   run' = fmap run' . runReader
+
+instance Run effects (Either (SomeExc exc) result) rest => Run (Resumable exc ': effects) result rest where
+  run' = run' . Resumable.runError
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -14,6 +14,7 @@ import Control.Monad.Effect.State
 import Control.Monad.Effect.Trace
 import Control.Monad.Effect.Writer
 
+-- | Elimination of effects.
 class Run effects result function | effects result -> function where
   run :: Eff.Eff effects result -> function
 

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -10,6 +10,7 @@ import Control.Monad.Effect.Internal as Eff
 import Control.Monad.Effect.NonDet
 import Control.Monad.Effect.Reader
 import Control.Monad.Effect.Resumable as Resumable
+import Control.Monad.Effect.State
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -37,6 +38,9 @@ instance Run effects result rest => Run (Reader b ': effects) result (b -> rest)
 
 instance Run effects (Either (SomeExc exc) result) rest => Run (Resumable exc ': effects) result rest where
   run' = run' . Resumable.runError
+
+instance Run effects (result, b) rest => Run (State b ': effects) result (b -> rest) where
+  run' = fmap run' . runState
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -6,7 +6,7 @@ import Control.Monad.Effect.Embedded
 import Control.Monad.Effect.Exception as Exc
 import Control.Monad.Effect.Fail
 import Control.Monad.Effect.Fresh
-import Control.Monad.Effect.Internal as Eff
+import qualified Control.Monad.Effect.Internal as Eff
 import Control.Monad.Effect.NonDet
 import Control.Monad.Effect.Reader
 import Control.Monad.Effect.Resumable as Resumable
@@ -15,13 +15,13 @@ import Control.Monad.Effect.Trace
 import Control.Monad.Effect.Writer
 
 class Run effects result function | effects result -> function where
-  run' :: Eff effects result -> function
+  run' :: Eff.Eff effects result -> function
 
 instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) -> rest) where
   run' = fmap run' . runCoro
 
 instance Run effects result rest => Run (Embedded effects ': effects) result rest where
-  run' = run' . relay pure (\ (Embed e) k -> e >>= k)
+  run' = run' . Eff.relay pure (\ (Embed e) k -> e >>= k)
 
 instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result rest where
   run' = run' . Exc.runError
@@ -51,7 +51,7 @@ instance (Monoid w, Run effects (result, w) rest) => Run (Writer w ': effects) r
   run' = run' . runWriter
 
 instance Run '[IO] result (IO result) where
-  run' = runM
+  run' = Eff.runM
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -8,6 +8,7 @@ import Control.Monad.Effect.Fail
 import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal as Eff
 import Control.Monad.Effect.NonDet
+import Control.Monad.Effect.Reader
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -29,6 +30,9 @@ instance Run effects result rest => Run (Fresh ': effects) result (Int -> rest) 
 
 instance (Run effects [result] rest) => Run (NonDet ': effects) result rest where
   run' = run' . runNonDet (:[])
+
+instance Run effects result rest => Run (Reader b ': effects) result (b -> rest) where
+  run' = fmap run' . runReader
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -15,43 +15,43 @@ import Control.Monad.Effect.Trace
 import Control.Monad.Effect.Writer
 
 class Run effects result function | effects result -> function where
-  run' :: Eff.Eff effects result -> function
+  run :: Eff.Eff effects result -> function
 
 instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) -> rest) where
-  run' = fmap run' . runCoro
+  run = fmap run . runCoro
 
 instance Run effects result rest => Run (Embedded effects ': effects) result rest where
-  run' = run' . Eff.relay pure (\ (Embed e) k -> e >>= k)
+  run = run . Eff.relay pure (\ (Embed e) k -> e >>= k)
 
 instance Run effects (Either exc result) rest => Run (Exc exc ': effects) result rest where
-  run' = run' . Exc.runError
+  run = run . Exc.runError
 
 instance Run effects (Either String result) rest => Run (Fail ': effects) result rest where
-  run' = run' . runFail
+  run = run . runFail
 
 instance Run effects result rest => Run (Fresh ': effects) result (Int -> rest) where
-  run' = fmap run' . runFresh'
+  run = fmap run . runFresh'
 
 instance (Run effects [result] rest) => Run (NonDet ': effects) result rest where
-  run' = run' . runNonDet (:[])
+  run = run . runNonDet (:[])
 
 instance Run effects result rest => Run (Reader b ': effects) result (b -> rest) where
-  run' = fmap run' . runReader
+  run = fmap run . runReader
 
 instance Run effects (Either (SomeExc exc) result) rest => Run (Resumable exc ': effects) result rest where
-  run' = run' . Resumable.runError
+  run = run . Resumable.runError
 
 instance Run effects (result, b) rest => Run (State b ': effects) result (b -> rest) where
-  run' = fmap run' . runState
+  run = fmap run . runState
 
 instance Run '[Trace] result (IO result) where
-  run' = runTrace
+  run = runTrace
 
 instance (Monoid w, Run effects (result, w) rest) => Run (Writer w ': effects) result rest where
-  run' = run' . runWriter
+  run = run . runWriter
 
 instance Run '[IO] result (IO result) where
-  run' = Eff.runM
+  run = Eff.runM
 
 instance Run '[] result result where
-  run' = Eff.run
+  run = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -1,1 +1,7 @@
+{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, TypeOperators, UndecidableInstances #-}
 module Control.Monad.Effect.Run where
+
+import Control.Monad.Effect.Internal as Eff
+
+class Run effects result function | effects result -> function where
+  run' :: Eff effects result -> function

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -18,6 +18,7 @@ import Control.Monad.Effect.Writer
 class Run effects result function | effects result -> function where
   run :: Eff.Eff effects result -> function
 
+
 instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) -> rest) where
   run = fmap run . runCoro
 

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -11,6 +11,7 @@ import Control.Monad.Effect.NonDet
 import Control.Monad.Effect.Reader
 import Control.Monad.Effect.Resumable as Resumable
 import Control.Monad.Effect.State
+import Control.Monad.Effect.Trace
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
@@ -41,6 +42,9 @@ instance Run effects (Either (SomeExc exc) result) rest => Run (Resumable exc ':
 
 instance Run effects (result, b) rest => Run (State b ': effects) result (b -> rest) where
   run' = fmap run' . runState
+
+instance Run '[Trace] result (IO result) where
+  run' = runTrace
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/Run.hs
+++ b/src/Control/Monad/Effect/Run.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, TypeOperators, UndecidableInstances #-}
 module Control.Monad.Effect.Run where
 
+import Control.Monad.Effect.Coroutine
 import Control.Monad.Effect.Internal as Eff
 
 class Run effects result function | effects result -> function where
   run' :: Eff effects result -> function
+
+instance Run effects result rest => Run (Yield a b ': effects) result ((a -> b) -> rest) where
+  run' = fmap run' . runCoro
 
 instance Run '[] result result where
   run' = Eff.run

--- a/src/Control/Monad/Effect/StateRW.hs
+++ b/src/Control/Monad/Effect/StateRW.hs
@@ -43,4 +43,4 @@ runStateR m s = loop s m
      Left  u'  -> case decompose u' of
        Right Reader -> k s' s'
        Left u'' -> E u'' (tsingleton (k s'))
-    where k s'' = q >>> (loop s'')
+    where k s'' = q >>> loop s''

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -37,7 +37,7 @@ trace = send . Trace
 
 -- | An IO handler for Trace effects
 runTrace :: Eff '[Trace] a -> IO a
-runTrace (Val x) = return x
+runTrace (Val x) = pure x
 runTrace (E u q) = case decompose u of
      Right (Trace s) -> putStrLn s >> runTrace (apply q ())
      Left _          -> error "runTrace:Left - This should never happen"

--- a/src/Control/Monad/Effect/Writer.hs
+++ b/src/Control/Monad/Effect/Writer.hs
@@ -36,5 +36,5 @@ tell o = send $ Writer o
 
 -- | Simple handler for Writer effects
 runWriter :: Monoid o => Eff (Writer o ': r) a -> Eff r (a,o)
-runWriter = relay (\x -> return (x,mempty))
-                  (\ (Writer o) k -> k () >>= \ (x,l) -> return (x,o `mappend` l))
+runWriter = relay (\x -> pure (x,mempty))
+                  (\ (Writer o) k -> k () >>= \ (x,l) -> pure (x,o `mappend` l))

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -104,12 +104,12 @@ instance (t :< '[t]) where
 -}
 
 -- | Inject a functor into a type-aligned union.
-inj :: forall e r v. e :< r => e v -> Union r v
+inj :: forall e r v. (e :< r) => e v -> Union r v
 inj = inj' (unP (elemNo :: P e r))
 {-# INLINE inj #-}
 
 -- | Maybe project a functor out of a type-aligned union.
-prj :: forall e r v. e :< r => Union r v -> Maybe (e v)
+prj :: forall e r v. (e :< r) => Union r v -> Maybe (e v)
 prj = prj' (unP (elemNo :: P e r))
 {-# INLINE prj #-}
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -143,7 +143,7 @@ class Apply (c :: (* -> *) -> Constraint) (fs :: [* -> *]) where
   apply :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
 
 apply' :: Apply c fs => proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
-apply' proxy f u@(Union n _) = apply proxy (\ r -> f (Union n) r) u
+apply' proxy f u@(Union n _) = apply proxy (f (Union n)) u
 {-# INLINABLE apply' #-}
 
 apply2 :: Apply c fs => proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -49,6 +49,7 @@ module Data.Union (
   Member,
   Members,
   MemberU2,
+  LastMember,
   Apply(..),
   apply',
   apply2,
@@ -175,6 +176,13 @@ class (t :< r) =>
 instance MemberU' 'True tag (tag e) (tag e ': r)
 instance (t :< (t' ': r), MemberU2 tag t r) =>
            MemberU' 'False tag t (t' ': r)
+
+
+-- | This class is resolvable only when @t@ is the last member of @ts@. This can be useful for e.g. embedding 'Monad'ic actions in @Eff@.
+class Member t ts => LastMember t ts
+instance (LastMember t ts, Member t (t' ': ts)) => LastMember t (t' ': ts)
+instance LastMember t '[t]
+
 
 instance Apply Foldable fs => Foldable (Union fs) where
   foldMap f = apply (Proxy :: Proxy Foldable) (foldMap f)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -49,7 +49,6 @@ module Data.Union (
   Member,
   Members,
   MemberU2,
-  LastMember,
   Apply(..),
   apply',
   apply2,
@@ -176,13 +175,6 @@ class (t :< r) =>
 instance MemberU' 'True tag (tag e) (tag e ': r)
 instance (t :< (t' ': r), MemberU2 tag t r) =>
            MemberU' 'False tag t (t' ': r)
-
-
--- | This class is resolvable only when @t@ is the last member of @ts@. This can be useful for e.g. embedding 'Monad'ic actions in @Eff@.
-class Member t ts => LastMember t ts
-instance (LastMember t ts, Member t (t' ': ts)) => LastMember t (t' ': ts)
-instance LastMember t '[t]
-
 
 instance Apply Foldable fs => Foldable (Union fs) where
   foldMap f = apply (Proxy :: Proxy Foldable) (foldMap f)

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -167,7 +167,7 @@ type family EQU (a :: * -> *) (b :: * -> *) :: Bool where
 
 -- This class is used for emulating monad transformers
 class (t :< r) => MemberU2 (tag :: (* -> *) -> * -> *) (t :: * -> *) r | tag r -> t
-instance (t1 :< r, MemberU' (EQU t1 t2) tag t1 (t2 ': r)) => MemberU2 tag t1 (t2 ': r)
+instance MemberU' (EQU t1 t2) tag t1 (t2 ': r) => MemberU2 tag t1 (t2 ': r)
 
 class (t :< r) =>
       MemberU' (f::Bool) (tag :: (* -> *) -> * -> *) (t :: * -> *) r | tag r -> t

--- a/tests/Tests/NonDet.hs
+++ b/tests/Tests/NonDet.hs
@@ -19,8 +19,8 @@ generatePrimes xs = do
   ifte (do d <- gen
            guard $ d < n && n `mod` d == 0)
        (const mzero)
-       (return n)
-  where gen = msum (fmap return xs)
+       (pure n)
+  where gen = msum (fmap pure xs)
 
 testIfte :: [Int] -> [Int]
 testIfte = run . makeChoiceA . generatePrimes


### PR DESCRIPTION
This PR provides a system for composite interpreters, using a `Run` typeclass which is able to completely eliminate effectful computations (or at least, in a couple of cases, interpret them into `IO`).

It further:

- provides an `interpret` helper inspired by [`freer-simple`](https://github.com/lexi-lambda/freer-simple)
- tweaks `Yield` to produce a value
- defines a `runCoro` eliminator for `Yield` which runs the resulting computation to completion with the assistance of a helper function which maps partial results to inputs
- exports a few handlers so we don’t have to import `Internal` so often
- defines `NonDet` into `Internal` so we can de-orphan the `Alternative` and `MonadPlus` instances
- resolves a longstanding issue preventing the use of `MemberU2`
- ~~defines a `LastMember` class, also inspired by `freer-simple`, and a `sendM` constructor to lift monadic actions into the final position~~ **Edit:** This didn’t work out.
- defines a `MonadIO` instance when ~~the `LastMember` has a `MonadIO` instance~~ `IO` is a `Member`
- applies a bunch of `hlint` hints