### PR TITLE
Add prettier type errors for ElemIndex failures.

### DIFF
--- a/effects.cabal
+++ b/effects.cabal
@@ -1,5 +1,5 @@
 name:                effects
-version:             0.3.0.0
+version:             0.3.0.1
 synopsis:            Implementation of the Freer Monad
 license:             BSD3
 license-file:        LICENSE

--- a/src/Data/Union/Templates.hs
+++ b/src/Data/Union/Templates.hs
@@ -9,11 +9,31 @@ import Unsafe.Coerce (unsafeCoerce)
 
 mkElemIndexTypeFamily :: Integer -> Dec
 mkElemIndexTypeFamily paramN =
-  ClosedTypeFamilyD (TypeFamilyHead elemIndex [KindedTV t functorK, KindedTV ts (AppT ListT functorK)] (KindSig (ConT nat)) Nothing) (mkEquation <$> [0..pred paramN])
+  ClosedTypeFamilyD (TypeFamilyHead elemIndex [KindedTV t functorK, KindedTV ts (AppT ListT functorK)] (KindSig (ConT nat)) Nothing) ((mkEquation <$> [0..pred paramN]) ++ errorCase)
   where [elemIndex, t, ts, nat] = mkName <$> ["ElemIndex", "t", "ts", "Nat"]
         functorK = AppT (AppT ArrowT StarT) StarT
         mkT = VarT . mkName . ('t' :) . show
         mkEquation i = TySynEqn [ mkT i, typeListT WildCardT (mkT <$> [0..i]) ] (LitT (NumTyLit i))
+        typeErrN = mkName "TypeError"
+        textN = mkName "Text"
+        next = mkName ":<>:"
+        above = mkName ":$$:"
+        shw = mkName "ShowType"
+        errorCase = [ TySynEqn
+                      [ VarT t , VarT ts ]
+                        (AppT
+                         (ConT typeErrN)
+                         (AppT
+                          (AppT (PromotedT above)
+                           (AppT (AppT (PromotedT next)
+                                  (AppT (AppT
+                                         (PromotedT next)
+                                         (AppT (PromotedT textN) (LitT (StrTyLit "'"))))
+                                               (AppT (PromotedT shw) (VarT t))))
+                           (AppT (PromotedT textN) (LitT (StrTyLit "' is not a member of the type-level list")))))
+                          (AppT (PromotedT shw) (VarT ts))))
+                    ]
+
 
 mkApplyInstance :: Integer -> Dec
 mkApplyInstance paramN =


### PR DESCRIPTION
Rather than showing a KnownNat error, a user will see this:

```
<interactive>:42:10: error:
    • 'Either String' is not a member of the type-level list
      '[Maybe, Down]
    • In the expression: (prj x) :: Maybe (Either String ())
      In an equation for 'y': y = (prj x) :: Maybe (Either String ())
```