### PR TITLE
Interpose state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.3.2.0 (April 25, 2018)
+
+* Added an `interposeState` handler.
+
 # 0.3.1.0 (April 25, 2018)
 
 * Exported all the effect data constructors.

--- a/effects.cabal
+++ b/effects.cabal
@@ -1,5 +1,5 @@
 name:                effects
-version:             0.3.1.0
+version:             0.3.2.0
 synopsis:            Implementation of the Freer Monad
 license:             BSD3
 license-file:        LICENSE

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -19,6 +19,7 @@ module Control.Monad.Effect (
   , relay
   , relayState
   , interpose
+  , interposeState
   , interpret
   -- * Checking a List of Effects#
   , type(:<)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -166,6 +166,8 @@ interpose ret h = loop
      _      -> E u (tsingleton k)
     where k = q >>> loop
 
+-- | Intercept an effect like 'interpose', but with an explicit state
+-- parameter like 'relayState'.
 interposeState :: (eff :< e)
                => s
                -> (s -> Arrow e a b)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -149,7 +149,7 @@ relayState s' pure' bind = loop s'
     loop s (E u' q)  = case decompose u' of
       Right x -> bind s x k
       Left  u -> E u (tsingleton (k s))
-     where k s'' x = loop s'' $ q `apply` x
+     where k s'' = q >>> loop s''
 
 -- | Intercept the request and possibly reply to it, but leave it
 -- unhandled

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -154,7 +154,7 @@ relayState s' pure' bind = loop s'
 -- | Intercept the request and possibly reply to it, but leave it
 -- unhandled
 interpose :: (eff :< e)
-          => (a -> Eff e b)
+          => Arrow e a b
           -> (forall v. eff v -> Arrow e v b -> Eff e b)
           -> Eff e a -> Eff e b
 interpose ret h = loop

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -159,8 +159,8 @@ interpose :: (eff :< e)
           -> Eff e a -> Eff e b
 interpose ret h = loop
  where
-   loop (Val x)  = ret x
-   loop (E u q)  = case prj u of
+   loop (Val x) = ret x
+   loop (E u q) = case prj u of
      Just x -> h x k
      _      -> E u (tsingleton k)
     where k = q >>> loop


### PR DESCRIPTION
This PR adds an `interposeState` handler à la `freer-simple`’s [`interposeS`](https://hackage.haskell.org/package/freer-simple-1.1.0.0/docs/Control-Monad-Freer-Internal.html#v:interposeS).