### PR TITLE
🔥 the membership operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ data Teletype s where
   GetLine     :: Teletype String
   ExitSuccess :: Teletype ()
 
-putStrLn' :: (Teletype :< r) => String -> Eff r ()
+putStrLn' :: Member Teletype r => String -> Eff r ()
 putStrLn' = send . PutStrLn
 
-getLine'  :: (Teletype :< r) => Eff r String
+getLine'  :: Member Teletype r => Eff r String
 getLine' = send GetLine
 
-exitSuccess' :: (Teletype :< r) => Eff r ()
+exitSuccess' :: Member Teletype r => Eff r ()
 exitSuccess' = send ExitSuccess
 
 --------------------------------------------------------------------------------

--- a/bench/Core.hs
+++ b/bench/Core.hs
@@ -58,16 +58,16 @@ data Http out where
   Post  :: String -> Http String
   Get   :: Http String
 
-open' :: (Http :< r) => String -> Eff r ()
+open' :: Member Http r => String -> Eff r ()
 open'  = send . Open
 
-close' :: (Http :< r) => Eff r ()
+close' :: Member Http r => Eff r ()
 close' = send Close
 
-post' :: (Http :< r) => String -> Eff r String
+post' :: Member Http r => String -> Eff r String
 post' = send . Post
 
-get' :: (Http :< r) => Eff r String
+get' :: Member Http r => Eff r String
 get' = send Get
 
 runHttp :: Eff (Http ': e) b -> Eff e b
@@ -113,13 +113,13 @@ runFHttp (Free.Free (FGet n))    = pure "" >>= runFHttp . n
 --------------------------------------------------------------------------------
                         -- Benchmark Suite --
 --------------------------------------------------------------------------------
-prog :: (Http :< r) => Eff r ()
+prog :: Member Http r => Eff r ()
 prog = open' "cats" >> get' >> post' "cats" >> close'
 
 prog' :: FHttp ()
 prog' = fopen' "cats" >> fget' >> fpost' "cats" >> fclose'
 
-p :: (Http :< r) => Int -> Eff r ()
+p :: Member Http r => Int -> Eff r ()
 p count   =  open' "cats" >> replicateM_ count (get' >> post' "cats") >>  close'
 
 p' :: Int -> FHttp ()

--- a/examples/src/Coroutine.hs
+++ b/examples/src/Coroutine.hs
@@ -5,10 +5,10 @@ module Coroutine where
 {-
 
 -- First example of coroutines
-yieldInt :: (Yield Int () :< r) => Int -> Eff r ()
+yieldInt :: (Member (Yield Int ()) r) => Int -> Eff r ()
 yieldInt = yield
 
-th1 :: (Yield Int () :< r) => Eff r ()
+th1 :: (Member (Yield Int ()) r) => Eff r ()
 th1 = yieldInt 1 >> yieldInt 2
 
 
@@ -27,7 +27,7 @@ Done
 -- Before it was
 --    th2 :: MonadReader Int m => CoT Int m ()
 -- Now it is more general:
-th2 :: ('[Yield Int (), Reader Int] :<: r) => Eff r ()
+th2 :: (Members '[Yield Int (), Reader Int] r) => Eff r ()
 th2 = ask >>= yieldInt >> (ask >>= yieldInt)
 
 
@@ -52,7 +52,7 @@ Done
 -}
 
 -- Real example, with two sorts of local rebinding
-th3 :: ('[Yield Int (), Reader Int] :<: r) => Eff r ()
+th3 :: (Members '[Yield Int (), Reader Int] r) => Eff r ()
 th3 = ay >> ay >> local (+(10::Int)) (ay >> ay)
  where ay = ask >>= yieldInt
 

--- a/examples/src/Cut.hs
+++ b/examples/src/Cut.hs
@@ -5,7 +5,7 @@ module Cut where
 
 {-
 -- The signature is inferred
-tcut1 :: ('[Choose r, Exc CutFalse] :<: r) => Eff r Int
+tcut1 :: (Members '[Choose r, Exc CutFalse] r) => Eff r Int
 tcut1 = (return (1::Int) `mplus'` return 2) `mplus'`
          ((cutfalse `mplus'` return 4) `mplus'`
           return 5)

--- a/examples/src/NonDet.hs
+++ b/examples/src/NonDet.hs
@@ -7,11 +7,11 @@ import Control.Monad
 import Control.Monad.Effect
 import Control.Monad.Effect.NonDet
 
-ifte :: (NonDet :< r)
+ifte :: Member NonDet r
      => Eff r a -> (a -> Eff r b) -> Eff r b -> Eff r b
 ifte t th el = (t >>= th) <|> el
 
-testIfte :: (NonDet :< r) => Eff r Int
+testIfte :: Member NonDet r => Eff r Int
 testIfte = do
   n <- gen
   ifte (do d <- gen

--- a/examples/src/Teletype.hs
+++ b/examples/src/Teletype.hs
@@ -14,15 +14,15 @@ data Teletype s where
   ExitSuccess :: Teletype ()
 
 -- Takes a string and returns a teletype effect.
-putStrLn' :: (Teletype :< e) => String -> Eff e ()
+putStrLn' :: Member Teletype e => String -> Eff e ()
 putStrLn' = send . PutStrLn
 
 -- Gets a line from a Teletype.
-getLine'  :: (Teletype :< e) => Eff e String
+getLine'  :: Member Teletype e => Eff e String
 getLine' = send GetLine
 
 -- An exit success effect that returns ().
-exitSuccess' :: (Teletype :< e) => Eff e ()
+exitSuccess' :: Member Teletype e => Eff e ()
 exitSuccess' = send ExitSuccess
 
 -- Runs a Teletype effect b and returns IO b.

--- a/examples/src/Trace.hs
+++ b/examples/src/Trace.hs
@@ -12,7 +12,7 @@ import Common
 -- Higher-order effectful function
 -- The inferred type shows that the Trace affect is added to the effects
 -- of r
-mapMdebug:: (Show a, Trace :< r) =>
+mapMdebug:: (Show a, Member Trace r) =>
      (a -> Eff r b) -> [a] -> Eff r [b]
 mapMdebug _ [] = return []
 mapMdebug f (h:t) = do

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -22,8 +22,6 @@ module Control.Monad.Effect (
   , interposeState
   , interpret
   -- * Checking a List of Effects#
-  , type(:<)
-  , type(:<:)
   , Member
   , Members
   , Embedded

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -36,7 +36,7 @@ data Yield a b v = Yield a (b -> v)
     deriving (Functor)
 
 -- | Lifts a value and a function into the Coroutine effect
-yield :: ((Yield a b) :< e) => a -> (b -> c) -> Eff e c
+yield :: Member (Yield a b) e => a -> (b -> c) -> Eff e c
 yield x f = send (Yield x f)
 
 -- |

--- a/src/Control/Monad/Effect/Cut.hs
+++ b/src/Control/Monad/Effect/Cut.hs
@@ -32,11 +32,11 @@ data CutFalse = CutFalse
 -- data Choose a b = Choose [a] b
 
 -- | Implementation of logical Cut using Exc effects.
-cutFalse :: (Exc CutFalse :< r) => Eff r a
+cutFalse :: Member (Exc CutFalse) r => Eff r a
 cutFalse = throwError CutFalse
 
 {-
-call :: (Exc CutFalse :< r) => Eff (Exc CutFalse ': r) a -> Eff r a
+call :: Member (Exc CutFalse) r => Eff (Exc CutFalse ': r) a -> Eff r a
 call m = loop [] m where
  loop jq (Val x) = pure x `mplus` next jq          -- (C2)
  loop jq (E u q) = case decompose u of

--- a/src/Control/Monad/Effect/Exception.hs
+++ b/src/Control/Monad/Effect/Exception.hs
@@ -34,7 +34,7 @@ import Control.Monad.Effect.Internal
 newtype Exc exc a = Exc exc
 
 -- | Throws an error carrying information of type 'exc'.
-throwError :: (Exc exc :< e) => exc -> Eff e a
+throwError :: Member (Exc exc) e => exc -> Eff e a
 throwError e = send (Exc e)
 
 -- | Handler for exception effects
@@ -47,6 +47,6 @@ runError =
 
 -- | A catcher for Exceptions. Handlers are allowed to rethrow
 -- exceptions.
-catchError :: (Exc exc :< e) =>
+catchError :: Member (Exc exc) e =>
         Eff e a -> (exc -> Eff e a) -> Eff e a
 catchError m handle = interpose pure (\(Exc e) _k -> handle e) m

--- a/src/Control/Monad/Effect/Fresh.hs
+++ b/src/Control/Monad/Effect/Fresh.hs
@@ -35,7 +35,7 @@ data Fresh v where
   Fresh :: Fresh Int
 
 -- | Request a fresh effect
-fresh :: (Fresh :< r) => Eff r Int
+fresh :: Member Fresh r => Eff r Int
 fresh = send Fresh
 
 -- | Handler for Fresh effects, with an Int for a starting value

--- a/src/Control/Monad/Effect/NonDet.hs
+++ b/src/Control/Monad/Effect/NonDet.hs
@@ -32,7 +32,7 @@ runNonDet f = relay (pure . f) (\ m k -> case m of
     MZero -> pure mempty
     MPlus -> mappend <$> k True <*> k False)
 
-gather :: (Monoid b, NonDet :< e)
+gather :: (Monoid b, Member NonDet e)
        => (a -> b) -- ^ A function constructing a 'Monoid'al value from a single computed result. This might typically be @unit@ (for @Reducer@s), 'pure' (for 'Applicative's), or some similar singleton constructor.
        -> Eff e a      -- ^ The computation to run locally-nondeterministically.
        -> Eff e b
@@ -49,7 +49,7 @@ makeChoiceA =
       MZero -> pure empty
       MPlus -> liftM2 (<|>) (k True) (k False)
 
-msplit :: (NonDet :< e)
+msplit :: Member NonDet e
        => Eff e a -> Eff e (Maybe (a, Eff e a))
 msplit = loop []
   where loop jq (Val x) = pure (Just (x, msum jq))

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -42,11 +42,11 @@ data Reader v a where
   Reader :: Reader a a
 
 -- | Request a value for the environment
-ask :: (Reader v :< e) => Eff e v
+ask :: Member (Reader v) e => Eff e v
 ask = send Reader
 
 -- | Request a value from the environment and applys as function
-asks :: (Reader v :< e) => (v -> a) -> Eff e a
+asks :: Member (Reader v) e => (v -> a) -> Eff e a
 asks f = f <$> ask
 
 -- | Handler for reader effects
@@ -57,7 +57,7 @@ runReader m e = interpret (\ Reader -> pure e) m
 -- Locally rebind the value in the dynamic environment
 -- This function is like a relay; it is both an admin for Reader requests,
 -- and a requestor of them
-local :: forall v b e. (Reader v :< e) =>
+local :: forall v b e. Member (Reader v) e =>
          (v -> v) -> Eff e b -> Eff e b
 local f m = do
   e0 <- ask

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -14,17 +14,17 @@ import Control.Monad.Effect.Internal
 data Resumable exc a where
   Resumable :: exc v -> Resumable exc v
 
-throwError :: forall exc v e. (Resumable exc :< e) => exc v -> Eff e v
+throwError :: forall exc v e. Member (Resumable exc) e => exc v -> Eff e v
 throwError e = send (Resumable e :: Resumable exc v)
 
 runError :: Eff (Resumable exc ': e) a -> Eff e (Either (SomeExc exc) a)
 runError = relay (pure . Right) (\ (Resumable e) _k -> pure (Left (SomeExc e)))
 
-resumeError :: forall exc e a. (Resumable exc :< e) =>
+resumeError :: forall exc e a. Member (Resumable exc) e =>
        Eff e a -> (forall v. Arrow e v a -> exc v -> Eff e a) -> Eff e a
 resumeError m handle = interpose @(Resumable exc) pure (\(Resumable e) yield -> handle yield e) m
 
-catchError :: forall exc e a. (Resumable exc :< e) => Eff e a -> (forall v. exc v -> Eff e a) -> Eff e a
+catchError :: forall exc e a. Member (Resumable exc) e => Eff e a -> (forall v. exc v -> Eff e a) -> Eff e a
 catchError m handle = resumeError m (const handle)
 
 data SomeExc exc where

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -53,23 +53,23 @@ data State s v where
   Put :: !s -> State s ()
 
 -- | Retrieve state
-get :: (State s :< e) => Eff e s
+get :: Member (State s) e => Eff e s
 get = send Get
 
 -- | Retrieve state, modulo a projection.
-gets :: (State s :< e) => (s -> a) -> Eff e a
+gets :: Member (State s) e => (s -> a) -> Eff e a
 gets f = f <$> get
 
 -- | Store state
-put :: (State s :< e) => s -> Eff e ()
+put :: Member (State s) e => s -> Eff e ()
 put s = send (Put s)
 
 -- | Modify state
-modify :: (State s :< e) => (s -> s) -> Eff e ()
+modify :: Member (State s) e => (s -> s) -> Eff e ()
 modify f = fmap f get >>= put
 
 -- | Modify state strictly
-modify' :: (State s :< e) => (s -> s) -> Eff e ()
+modify' :: Member (State s) e => (s -> s) -> Eff e ()
 modify' f = do
   v <- get
   put $! f v
@@ -78,7 +78,7 @@ modify' f = do
 -- An encapsulated State handler, for transactional semantics
 -- The global state is updated only if the transactionState finished
 -- successfully
-transactionState :: forall s e a. (State s :< e)
+transactionState :: forall s e a. Member (State s) e
                     => Proxy s
                     -> Eff e a
                     -> Eff e a

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -32,7 +32,7 @@ data Trace v where
   Trace :: String -> Trace ()
 
 -- | Printing a string in a trace
-trace :: (Trace :< e) => String -> Eff e ()
+trace :: Member Trace e => String -> Eff e ()
 trace = send . Trace
 
 -- | An IO handler for Trace effects

--- a/src/Control/Monad/Effect/Writer.hs
+++ b/src/Control/Monad/Effect/Writer.hs
@@ -31,7 +31,7 @@ data Writer o x where
   Writer :: o -> Writer o ()
 
 -- | Send a change to the attached environment
-tell :: (Writer o :< r) => o -> Eff r ()
+tell :: Member (Writer o) r => o -> Eff r ()
 tell o = send $ Writer o
 
 -- | Simple handler for Writer effects

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -44,8 +44,6 @@ module Data.Union (
   weaken,
   inj,
   prj,
-  type(:<),
-  type(:<:),
   Member,
   Members,
   MemberU2,
@@ -66,8 +64,6 @@ import GHC.TypeLits
 
 pure [mkElemIndexTypeFamily 150]
 
-infixr 5 :<
-
 -- Strong Sum (Existential with the evidence) is an open union
 -- t is can be a GADT and hence not necessarily a Functor.
 -- Int is the index of t in the list r; that is, the index of t in the
@@ -86,17 +82,14 @@ prj' n (Union n' x) | n == n'   = Just (unsafeCoerce x)
 
 newtype P (t :: * -> *) (r :: [* -> *]) = P { unP :: Int }
 
-infixr 5 :<:
 -- | Find a list of members 'ms' in an open union 'r'.
 type family Members ms r :: Constraint where
   Members (t ': cs) r = (Member t r, Members cs r)
   Members '[] r = ()
 
-type (ts :<: r) = Members ts r
-
 {-
 -- Optimized specialized instance
-instance (t :< '[t]) where
+instance (Member t '[t]) where
   {-# INLINE inj #-}
   {-# INLINE prj #-}
   inj x           = Union 0 x
@@ -104,12 +97,12 @@ instance (t :< '[t]) where
 -}
 
 -- | Inject a functor into a type-aligned union.
-inj :: forall e r v. (e :< r) => e v -> Union r v
+inj :: forall e r v. Member e r => e v -> Union r v
 inj = inj' (unP (elemNo :: P e r))
 {-# INLINE inj #-}
 
 -- | Maybe project a functor out of a type-aligned union.
-prj :: forall e r v. (e :< r) => Union r v -> Maybe (e v)
+prj :: forall e r v. Member e r => Union r v -> Maybe (e v)
 prj = prj' (unP (elemNo :: P e r))
 {-# INLINE prj #-}
 
@@ -131,11 +124,10 @@ weaken :: Union r w -> Union (any ': r) w
 weaken (Union n v) = Union (n+1) v
 
 type (Member t r) = KnownNat (ElemIndex t r)
-type (t :< r) = Member t r
 
 -- Find an index of an element in an `r'.
 -- The element must exist, so this is essentially a compile-time computation.
-elemNo :: forall t r . (t :< r) => P t r
+elemNo :: forall t r . Member t r => P t r
 elemNo = P (fromIntegral (natVal' (proxy# :: Proxy# (ElemIndex t r))))
 
 -- | Helper to apply a function to a functor of the nth type in a type list.
@@ -166,14 +158,14 @@ type family EQU (a :: * -> *) (b :: * -> *) :: Bool where
   EQU a b = 'False
 
 -- This class is used for emulating monad transformers
-class (t :< r) => MemberU2 (tag :: (* -> *) -> * -> *) (t :: * -> *) r | tag r -> t
-instance MemberU' (EQU t1 t2) tag t1 (t2 ': r) => MemberU2 tag t1 (t2 ': r)
+class Member t r => MemberU2 (tag :: (* -> *) -> * -> *) (t :: * -> *) r | tag r -> t
+instance (Member t1 (t2 ': r), MemberU' (EQU t1 t2) tag t1 (t2 ': r)) => MemberU2 tag t1 (t2 ': r)
 
-class (t :< r) =>
+class Member t r =>
       MemberU' (f::Bool) (tag :: (* -> *) -> * -> *) (t :: * -> *) r | tag r -> t
 
 instance MemberU' 'True tag (tag e) (tag e ': r)
-instance (t :< (t' ': r), MemberU2 tag t r) =>
+instance (Member t (t' ': r), MemberU2 tag t r) =>
            MemberU' 'False tag t (t' ': r)
 
 instance Apply Foldable fs => Foldable (Union fs) where

--- a/tests/Tests/Coroutine.hs
+++ b/tests/Tests/Coroutine.hs
@@ -14,7 +14,7 @@ import Control.Monad.Effect.State
 runTestCoroutine :: [Int] -> Int
 runTestCoroutine list = snd . run $ runState effTestCoroutine 0
   where
-    testCoroutine :: ('[Yield () Int, State Int] :<: e) => Eff e ()
+    testCoroutine :: Members '[Yield () Int, State Int] e => Eff e ()
     testCoroutine = do
       -- yield for two elements and hope they're both odd
       b <- (&&)

--- a/tests/Tests/Exception.hs
+++ b/tests/Tests/Exception.hs
@@ -30,15 +30,15 @@ testExceptionTakesPriority x y = run $ runError (go x y)
 -- The following won't type: unhandled exception!
 -- ex2rw = run et2
 {-
-    No instance for (Exc Int :< Void)
+    No instance for (Member (Exc Int) Void)
       arising from a use of `et2'
 -}
 
 -- exceptions and state
-incr :: (State Int :< r) => Eff r ()
+incr :: Member (State Int) r => Eff r ()
 incr = get >>= put . (+ (1::Int))
 
-tes1 :: ('[State Int, Exc String] :<: r) => Eff r b
+tes1 :: Members '[State Int, Exc String] r => Eff r b
 tes1 = do
  incr
  throwError "exc"
@@ -49,7 +49,7 @@ ter1 = run $ runState (runError tes1) (1::Int)
 ter2 :: Either String (String, Int)
 ter2 = run $ runError (runState tes1 (1::Int))
 
-teCatch :: (Exc String :< r) => Eff r a -> Eff r String
+teCatch :: Member (Exc String) r => Eff r a -> Eff r String
 teCatch m = catchError (m >> pure "done") (\e -> pure (e::String))
 
 ter3 :: (Either String String, Int)
@@ -61,7 +61,7 @@ ter4 = run $ runError (runState (teCatch tes1) (1::Int))
 -- The example from the paper
 newtype TooBig = TooBig Int deriving (Eq, Show)
 
-ex2 :: (Exc TooBig :< r) => Eff r Int -> Eff r Int
+ex2 :: Member (Exc TooBig) r => Eff r Int -> Eff r Int
 ex2 m = do
   v <- m
   if v > 5 then throwError (TooBig v)

--- a/tests/Tests/NonDet.hs
+++ b/tests/Tests/NonDet.hs
@@ -6,14 +6,14 @@ import Control.Monad
 import Control.Monad.Effect
 import Control.Monad.Effect.NonDet
 
-ifte :: (NonDet :< e)
+ifte :: Member NonDet e
      => Eff e a
      -> (a -> Eff e b)
      -> Eff e b
      -> Eff e b
 ifte t th el = msplit t >>= maybe el (\(a,m) -> th a <|> (m >>= th))
 
-generatePrimes :: (NonDet :< e) => [Int] -> Eff e Int
+generatePrimes :: Member NonDet e => [Int] -> Eff e Int
 generatePrimes xs = do
   n <- gen
   ifte (do d <- gen

--- a/tests/Tests/Reader.hs
+++ b/tests/Tests/Reader.hs
@@ -18,7 +18,7 @@ testReader n x = run . flip runReader n $ ask `add` pure x
 
 {-
 t1rr' = run t1
-    No instance for (Reader Int :< Void)
+    No instance for (Member (Reader Int) Void)
       arising from a use of `t1'
 -}
 
@@ -32,7 +32,7 @@ testMultiReader f n = run . flip runReader f . flip runReader n $ t2
 -- The opposite order of layers
 {- If we mess up, we get an error
 t2rrr1' = run $ runReader (runReader t2 (20::Float)) (10::Float)
-    No instance for (Reader Int :< [])
+    No instance for (Member (Reader Int) [])
       arising from a use of `t2'
 -}
 


### PR DESCRIPTION
`:<` is kind of opaque, and breaks `haskell-src-exts`. Thus, 🔥

- [x] 🔥’s the `:<` and `:<:` operators in favour of `Member`/`Members`.
- [x] Depends on #34.

Since this is a breaking change we’ll want to bump the version, but since we have some other breaking changes planned (#23, #35), we might want to wait to actually apply the bump.