### PR TITLE
🔥 Apply

### DIFF
--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -47,16 +47,8 @@ module Data.Union (
   Member,
   Members,
   MemberU2,
-  Apply(..),
-  apply',
-  apply2,
-  apply2'
 ) where
 
-import Data.Functor.Classes (Eq1(..), eq1, Ord1(..), compare1, Show1(..), showsPrec1)
-import Data.Maybe (fromMaybe)
-import Data.Proxy
-import Data.Union.Templates
 import Unsafe.Coerce(unsafeCoerce)
 import GHC.Exts (Constraint)
 import GHC.Prim (Proxy#, proxy#)
@@ -130,28 +122,6 @@ type (Member t r) = KnownNat (ElemIndex t r)
 elemNo :: forall t r . Member t r => P t r
 elemNo = P (fromIntegral (natVal' (proxy# :: Proxy# (ElemIndex t r))))
 
--- | Helper to apply a function to a functor of the nth type in a type list.
-class Apply (c :: (* -> *) -> Constraint) (fs :: [* -> *]) where
-  apply :: proxy c -> (forall g . c g => g a -> b) -> Union fs a -> b
-
-apply' :: Apply c fs => proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> b) -> Union fs a -> b
-apply' proxy f u@(Union n _) = apply proxy (f (Union n)) u
-{-# INLINABLE apply' #-}
-
-apply2 :: Apply c fs => proxy c -> (forall g . c g => g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
-apply2 proxy f u@(Union n1 _) (Union n2 r2)
-  | n1 == n2  = Just (apply proxy (\ r1 -> f r1 (unsafeCoerce r2)) u)
-  | otherwise = Nothing
-{-# INLINABLE apply2 #-}
-
-apply2' :: Apply c fs => proxy c -> (forall g . c g => (forall x. g x -> Union fs x) -> g a -> g b -> d) -> Union fs a -> Union fs b -> Maybe d
-apply2' proxy f u@(Union n1 _) (Union n2 r2)
-  | n1 == n2  = Just (apply' proxy (\ reinj r1 -> f reinj r1 (unsafeCoerce r2)) u)
-  | otherwise = Nothing
-{-# INLINABLE apply2' #-}
-
-pure (mkApplyInstance <$> [1..150])
-
 
 type family EQU (a :: * -> *) (b :: * -> *) :: Bool where
   EQU a a = 'True
@@ -167,60 +137,3 @@ class Member t r =>
 instance MemberU' 'True tag (tag e) (tag e ': r)
 instance (Member t (t' ': r), MemberU2 tag t r) =>
            MemberU' 'False tag t (t' ': r)
-
-instance Apply Foldable fs => Foldable (Union fs) where
-  foldMap f = apply (Proxy :: Proxy Foldable) (foldMap f)
-  {-# INLINABLE foldMap #-}
-
-  foldr combine seed = apply (Proxy :: Proxy Foldable) (foldr combine seed)
-  {-# INLINABLE foldr #-}
-
-  foldl combine seed = apply (Proxy :: Proxy Foldable) (foldl combine seed)
-  {-# INLINABLE foldl #-}
-
-  null = apply (Proxy :: Proxy Foldable) null
-  {-# INLINABLE null #-}
-
-  length = apply (Proxy :: Proxy Foldable) length
-  {-# INLINABLE length #-}
-
-instance Apply Functor fs => Functor (Union fs) where
-  fmap f = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (fmap f a))
-  {-# INLINABLE fmap #-}
-
-  (<$) v = apply' (Proxy :: Proxy Functor) (\ reinj a -> reinj (v <$ a))
-  {-# INLINABLE (<$) #-}
-
-instance (Apply Foldable fs, Apply Functor fs, Apply Traversable fs) => Traversable (Union fs) where
-  traverse f = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> traverse f a)
-  {-# INLINABLE traverse #-}
-
-  sequenceA = apply' (Proxy :: Proxy Traversable) (\ reinj a -> reinj <$> sequenceA a)
-  {-# INLINABLE sequenceA #-}
-
-
-instance Apply Eq1 fs => Eq1 (Union fs) where
-  liftEq eq u1 u2 = fromMaybe False (apply2 (Proxy :: Proxy Eq1) (liftEq eq) u1 u2)
-  {-# INLINABLE liftEq #-}
-
-instance (Apply Eq1 fs, Eq a) => Eq (Union fs a) where
-  (==) = eq1
-  {-# INLINABLE (==) #-}
-
-
-instance (Apply Eq1 fs, Apply Ord1 fs) => Ord1 (Union fs) where
-  liftCompare compareA u1@(Union n1 _) u2@(Union n2 _) = fromMaybe (compare n1 n2) (apply2 (Proxy :: Proxy Ord1) (liftCompare compareA) u1 u2)
-  {-# INLINABLE liftCompare #-}
-
-instance (Apply Eq1 fs, Apply Ord1 fs, Ord a) => Ord (Union fs a) where
-  compare = compare1
-  {-# INLINABLE compare #-}
-
-
-instance Apply Show1 fs => Show1 (Union fs) where
-  liftShowsPrec sp sl d = apply (Proxy :: Proxy Show1) (liftShowsPrec sp sl d)
-  {-# INLINABLE liftShowsPrec #-}
-
-instance (Apply Show1 fs, Show a) => Show (Union fs a) where
-  showsPrec = showsPrec1
-  {-# INLINABLE showsPrec #-}

--- a/src/Data/Union/Templates.hs
+++ b/src/Data/Union/Templates.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Data.Union.Templates
 ( mkElemIndexTypeFamily
-, mkApplyInstance
 ) where
 
 import Language.Haskell.TH
@@ -34,20 +33,6 @@ mkElemIndexTypeFamily paramN =
                           (AppT (PromotedT shw) (VarT ts))))
                     ]
 
-
-mkApplyInstance :: Integer -> Dec
-mkApplyInstance paramN =
-  InstanceD Nothing (AppT constraint <$> typeParams) (AppT (AppT (ConT applyC) constraint) (typeListT PromotedNilT typeParams))
-    [ FunD apply (zipWith mkClause [0..] typeParams)
-    , PragmaD (InlineP apply Inlinable FunLike AllPhases)
-    ]
-  where typeParams = VarT . mkName . ('f' :) . show <$> [0..pred paramN]
-        [applyC, apply, f, r, union] = mkName <$> ["Apply", "apply", "f", "r", "Union"]
-        [constraint, a] = VarT . mkName <$> ["constraint", "a"]
-        mkClause i nthType = Clause
-          [ WildP, VarP f, ConP union [ LitP (IntegerL i), VarP r ] ]
-          (NormalB (AppE (VarE f) (SigE (AppE (VarE 'unsafeCoerce) (VarE r)) (AppT nthType a))))
-          []
 
 typeListT :: Type -> [Type] -> Type
 typeListT = foldr (AppT . AppT PromotedConsT)

--- a/src/Data/Union/Templates.hs
+++ b/src/Data/Union/Templates.hs
@@ -4,7 +4,6 @@ module Data.Union.Templates
 ) where
 
 import Language.Haskell.TH
-import Unsafe.Coerce (unsafeCoerce)
 
 mkElemIndexTypeFamily :: Integer -> Dec
 mkElemIndexTypeFamily paramN =


### PR DESCRIPTION
In support of #35, this PR 🔥s `Apply` since we’re not going to need it once we have a syntax-purposed `Union` elsewhere.

- [ ] Depends on #34.
- [ ] Depends on #36.
- [x] Fixes #23.