### PR TITLE
[WIP] Different type aligned queue representation

### DIFF
--- a/effects.cabal
+++ b/effects.cabal
@@ -56,6 +56,7 @@ library
                      , Data.Union
   build-depends:       base >=4.7 && <5
                      , template-haskell
+                     , type-aligned
                      , async
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -49,7 +49,7 @@ data Status e a b w = Done w | Continue a (b -> Eff e (Status e a b w))
 runC :: Eff (Yield a b ': e) w -> Eff e (Status e a b w)
 runC = relay (pure . Done) bind
   where
-    bind :: Yield a b v -> Arrow e v (Status e a b w) -> Eff e (Status e a b w)
+    bind :: Yield a b v -> (v -> Eff e (Status e a b w)) -> Eff e (Status e a b w)
     bind (Yield a k) arr = pure $ Continue a (arr . k)
 
 -- | Launch a thread and run it to completion using a helper function to provide new inputs.

--- a/src/Control/Monad/Effect/Embedded.hs
+++ b/src/Control/Monad/Effect/Embedded.hs
@@ -46,7 +46,7 @@ raiseEmbedded :: Raisable m r => Eff m a -> Eff r a
 raiseEmbedded = loop
   where
     loop (Val x)  = pure x
-    loop (E u' q) = raiseUnion u' >>= (q >>> loop)
+    loop (E u' q) = raiseUnion u' >>= runArrow (q >>> loop)
 
 liftEmbedded :: (Raisable m r) => Eff (Embedded m ': r) a -> Eff r a
 liftEmbedded = runEmbedded void

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -129,7 +129,7 @@ relay :: (a -> Eff e b) -- ^ An 'pure' effectful arrow.
       -> Eff e b -- ^ The relayed effect with 'eff' consumed.
 relay pure' bind = loop
  where
-  loop (Val x)  = pure' x
+  loop (Val x)   = pure' x
   loop (E u' q)  = case decompose u' of
     Right x -> bind x k
     Left  u -> E u (tsingleton k)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -27,7 +27,7 @@ module Control.Monad.Effect.Internal (
   , decompose
   , Queue
   , tsingleton
-  , Arrow
+  , Arrow(..)
   , Union
   -- * Composing and Applying Effects
   , apply
@@ -64,7 +64,7 @@ type Queue effects a b = FTCQueue (Eff effects) a b
 
 -- | An effectful function from 'a' to 'b'
 --   that also performs a list of 'effects'.
-type Arrow effects a b = a -> Eff effects b
+newtype Arrow effects a b = Arrow { runArrow :: a -> Eff effects b }
 
 -- * Composing and Applying Effects
 
@@ -80,13 +80,13 @@ apply q' x =
 -- | Compose queues left to right.
 (>>>) :: Queue effects a b
       -> (Eff effects b -> Eff effects' c) -- ^ An function to compose.
-      -> Arrow effects' a c
+      -> (a -> Eff effects' c)
 (>>>) queue f = f . apply queue
 
 -- | Compose queues right to left.
 (<<<) :: (Eff effects b -> Eff effects' c) -- ^ An function to compose.
       -> Queue effects  a b
-      -> Arrow effects' a c
+      -> (a -> Eff effects' c)
 (<<<) f queue  = f . apply queue
 
 -- * Sending and Running Effects

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -46,6 +46,7 @@ module Control.Monad.Effect.Internal (
 ) where
 
 import Control.Applicative (Alternative(..))
+import qualified Control.Arrow as Arr
 import qualified Control.Category as Cat
 import Control.Monad (MonadPlus(..), (<=<))
 import Control.Monad.Fail (MonadFail(..))
@@ -70,6 +71,10 @@ newtype Arrow effects a b = Arrow { runArrow :: a -> Eff effects b }
 instance Cat.Category (Arrow effects) where
   id = Arrow pure
   Arrow runB . Arrow runA = Arrow (runB <=< runA)
+
+instance Arr.Arrow (Arrow effects) where
+  arr f = Arrow (pure . f)
+  Arrow runA *** Arrow runB = Arrow (\ (a, b) -> (,) <$> runA a <*> runB b)
 
 -- * Composing and Applying Effects
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -82,7 +82,7 @@ instance Arr.Arrow (Arrow effects) where
 apply :: Queue effects a b -> a -> Eff effects b
 apply q' x =
    case tviewl q' of
-   TOneL k -> runArrow k x
+   TAEmptyL -> pure x
    k :< t  -> case runArrow k x of
      Val y -> t `apply` y
      E u q -> E u (q >< t)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -46,7 +46,8 @@ module Control.Monad.Effect.Internal (
 ) where
 
 import Control.Applicative (Alternative(..))
-import Control.Monad (MonadPlus(..))
+import qualified Control.Category as Cat
+import Control.Monad (MonadPlus(..), (<=<))
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Union
@@ -65,6 +66,10 @@ type Queue effects a b = FTCQueue (Arrow effects) a b
 -- | An effectful function from 'a' to 'b'
 --   that also performs a list of 'effects'.
 newtype Arrow effects a b = Arrow { runArrow :: a -> Eff effects b }
+
+instance Cat.Category (Arrow effects) where
+  id = Arrow pure
+  Arrow runB . Arrow runA = Arrow (runB <=< runA)
 
 -- * Composing and Applying Effects
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -121,10 +121,10 @@ runM (E u q) = case decompose u of
 
 -- | Given an effect request, either handle it with the given 'pure' function,
 -- or relay it to the given 'bind' function.
-relay :: Arrow e a b -- ^ An 'pure' effectful arrow.
+relay :: (a -> Eff e b) -- ^ An 'pure' effectful arrow.
       -- | A function to relay to, that binds a relayed 'eff v' to
       -- an effectful arrow and returns a new effect.
-      -> (forall v. eff v -> Arrow e v b -> Eff e b)
+      -> (forall v. eff v -> (v -> Eff e b) -> Eff e b)
       -> Eff (eff ': e) a -- ^ The 'eff' to relay and consume.
       -> Eff e b -- ^ The relayed effect with 'eff' consumed.
 relay pure' bind = loop
@@ -140,7 +140,7 @@ relay pure' bind = loop
 -- effect, or relayed to a handler that can handle the target effect.
 relayState :: s
            -> (s -> a -> Eff e b)
-           -> (forall v. s -> eff v -> (s -> Arrow e v b) -> Eff e b)
+           -> (forall v. s -> eff v -> (s -> v -> Eff e b) -> Eff e b)
            -> Eff (eff ': e) a
            -> Eff e b
 relayState s' pure' bind = loop s'
@@ -154,8 +154,8 @@ relayState s' pure' bind = loop s'
 -- | Intercept the request and possibly reply to it, but leave it
 -- unhandled
 interpose :: Member eff e
-          => Arrow e a b
-          -> (forall v. eff v -> Arrow e v b -> Eff e b)
+          => (a -> Eff e b)
+          -> (forall v. eff v -> (v -> Eff e b) -> Eff e b)
           -> Eff e a -> Eff e b
 interpose ret h = loop
  where
@@ -169,8 +169,8 @@ interpose ret h = loop
 -- parameter like 'relayState'.
 interposeState :: Member eff e
                => s
-               -> (s -> Arrow e a b)
-               -> (forall v. s -> eff v -> (s -> Arrow e v b) -> Eff e b)
+               -> (s -> a -> Eff e b)
+               -> (forall v. s -> eff v -> (s -> v -> Eff e b) -> Eff e b)
                -> Eff e a
                -> Eff e b
 interposeState initial ret handler = loop initial

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -82,8 +82,8 @@ instance Arr.Arrow (Arrow effects) where
 apply :: Queue effects a b -> a -> Eff effects b
 apply q' x =
    case tviewl q' of
-   TOne k  -> runArrow k x
-   k :< t -> case runArrow k x of
+   TOneL k -> runArrow k x
+   k :< t  -> case runArrow k x of
      Val y -> t `apply` y
      E u q -> E u (q >< t)
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -62,7 +62,7 @@ data Eff effects b
   | forall a. E (Union effects a) (Queue effects a b)
 
 -- | A queue of effects to apply from 'a' to 'b'.
-type Queue effects a b = FTCQueue (Arrow effects) a b
+type Queue effects = FTCQueue (Arrow effects)
 
 -- | An effectful function from 'a' to 'b'
 --   that also performs a list of 'effects'.

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -62,7 +62,7 @@ local :: forall v b e. Member (Reader v) e =>
 local f m = do
   e0 <- ask
   let e = f e0
-  let bind :: Reader v a -> Arrow e a b -> Eff e b
+  let bind :: Reader v a -> (a -> Eff e b) -> Eff e b
       bind Reader g = g e
   interpose pure bind m
 

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -21,7 +21,7 @@ runError :: Eff (Resumable exc ': e) a -> Eff e (Either (SomeExc exc) a)
 runError = relay (pure . Right) (\ (Resumable e) _k -> pure (Left (SomeExc e)))
 
 resumeError :: forall exc e a. Member (Resumable exc) e =>
-       Eff e a -> (forall v. Arrow e v a -> exc v -> Eff e a) -> Eff e a
+       Eff e a -> (forall v. (v -> Eff e a) -> exc v -> Eff e a) -> Eff e a
 resumeError m handle = interpose @(Resumable exc) pure (\(Resumable e) yield -> handle yield e) m
 
 catchError :: forall exc e a. Member (Resumable exc) e => Eff e a -> (forall v. exc v -> Eff e a) -> Eff e a

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -42,7 +42,7 @@ import Data.Proxy
 runState :: Eff (State s ': e) b -> s -> Eff e (b, s)
 runState (Val b) s = pure (b, s)
 runState (E u q) s = case decompose u of
-  Left  u'       -> E u' $ tsingleton (flip runState s . apply q)
+  Left  u'       -> E u' $ tsingleton (Arrow (flip runState s . apply q))
   Right Get      -> runState (apply q s) s
   Right (Put s') -> runState (apply q ()) s'
 

--- a/src/Control/Monad/Effect/StateRW.hs
+++ b/src/Control/Monad/Effect/StateRW.hs
@@ -39,8 +39,8 @@ runStateR m s = loop s m
    loop :: s -> Eff (Writer s ': Reader s ': e) a -> Eff e (a, s)
    loop s' (Val x) = pure (x,s')
    loop s' (E u q) = case decompose u of
-     Right (Writer o) -> k o ()
+     Right (Writer o) -> runArrow (k o) ()
      Left  u'  -> case decompose u' of
-       Right Reader -> k s' s'
+       Right Reader -> runArrow (k s') s'
        Left u'' -> E u'' (tsingleton (k s'))
     where k s'' = q >>> loop s''

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -38,7 +38,7 @@ data FTCQueue arrow a b where
   Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 
 class TANonEmptySequence sequence where
-  {-# MINIMAL tsingleton, ((><) | (<|)), (tviewl | tviewr), tmap #-}
+  {-# MINIMAL tsingleton, ((><) | (<|) | (|>)), (tviewl | tviewr), tmap #-}
   -- | Build a leaf from a single operation
   tsingleton :: arrow x y -> sequence arrow x y
 

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -45,6 +45,10 @@ class TANonEmptySequence sequence where
   (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
   as |> a = as >< tsingleton a
 
+  -- | Append an operation to the left of the tree
+  (<|) :: arrow x y -> sequence arrow y z -> sequence arrow x z
+  a <| as = tsingleton a >< as
+
   -- | Append two trees of operations
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
 

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs, RankNTypes #-}
 
 {-|
 Module      : Data.FTCQueue
@@ -43,6 +43,8 @@ class TANonEmptySequence sequence where
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
   -- | Left view deconstruction [average O(1)]
   tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y
+  -- | Map over leaf arrows [O(n)]
+  tmap :: (forall x y. arrow x y -> arrow' x y) -> sequence arrow x y -> sequence arrow' x y
 
 data TANonEmptyViewL s arrow a b where
   TOne  :: arrow a b -> TANonEmptyViewL s arrow a b
@@ -64,3 +66,6 @@ instance TANonEmptySequence FTCQueue where
       go :: FTCQueue arrow a x -> FTCQueue arrow x b -> TANonEmptyViewL FTCQueue arrow a b
       go (Leaf r) tr = r :< tr
       go (Node tl1 tl2) tr = go tl1 (Node tl2 tr)
+
+  tmap f (Leaf r) = Leaf (f r)
+  tmap f (Node l r) = Node (tmap f l) (tmap f r)

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -9,7 +9,7 @@ Maintainer  : allele.dev@gmail.com
 Stability   : experimental
 Portability : POSIX
 
-* Constant-time append/(><) and snoc/(|>)
+* Constant-time (><) and (|>)
 * Average constant-time viewL (left-edge deconstruction)
 
 Using <http://okmij.org/ftp/Haskell/extensible/FTCQueue1.hs> as a
@@ -25,9 +25,7 @@ module Data.FTCQueue (
   FTCQueue,
   tsingleton,
   (|>),
-  snoc,
   (><),
-  append,
   ViewL(..),
   tviewl
 ) where
@@ -49,20 +47,10 @@ tsingleton = Leaf
 t |> r = Node t (Leaf r)
 {-# INLINE (|>) #-}
 
--- | An alias for '(|>)'
-snoc :: FTCQueue m a x -> (x -> m b) -> FTCQueue m a b
-snoc = (|>)
-{-# INLINE snoc #-}
-
 -- | Append two trees of operations [O(1)]
 (><)   :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
 t1 >< t2 = Node t1 t2
 {-# INLINE (><) #-}
-
--- | An alias for '(><)'
-append :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
-append = (><)
-{-# INLINE append #-}
 
 -- | Left view deconstruction data structure
 data ViewL m a b where

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -55,7 +55,7 @@ class TANonEmptySequence sequence where
   tmap :: (forall x y. arrow x y -> arrow' x y) -> sequence arrow x y -> sequence arrow' x y
 
 data TANonEmptyViewL s arrow a b where
-  TOne  :: arrow a b -> TANonEmptyViewL s arrow a b
+  TOneL :: arrow a b -> TANonEmptyViewL s arrow a b
   (:<)  :: arrow a x -> s arrow x b -> TANonEmptyViewL s arrow a b
 
 instance TANonEmptySequence FTCQueue where
@@ -68,7 +68,7 @@ instance TANonEmptySequence FTCQueue where
   t1 >< t2 = Node t1 t2
   {-# INLINE (><) #-}
 
-  tviewl (Leaf r) = TOne r
+  tviewl (Leaf r) = TOneL r
   tviewl (Node t1 t2) = go t1 t2
     where
       go :: FTCQueue arrow a x -> FTCQueue arrow x b -> TANonEmptyViewL FTCQueue arrow a b

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -23,92 +23,10 @@ A minimal version of FTCQueue from "Reflection w/o Remorse":
 -}
 module Data.FTCQueue
 ( FTCQueue
-, TANonEmptySequence(..)
-, TANonEmptyViewL(..)
-, TANonEmptyViewR(..)
+, TASequence(..)
+, TAViewL(..)
 ) where
 
-import qualified Control.Category as Cat
+import Data.TASequence.BinaryTree
 
--- |
--- Non-empty tree. Deconstruction operations make it more and more
--- left-leaning
-data FTCQueue arrow a b where
-  Leaf :: arrow a b -> FTCQueue arrow a b
-  Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
-
-class TANonEmptySequence sequence where
-  {-# MINIMAL tsingleton, ((><) | (<|) | (|>)), (tviewl | tviewr), tmap #-}
-  -- | Build a leaf from a single operation
-  tsingleton :: arrow x y -> sequence arrow x y
-
-  -- | Append an operation to the right of the tree
-  (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
-  as |> a = as >< tsingleton a
-
-  -- | Append an operation to the left of the tree
-  (<|) :: arrow x y -> sequence arrow y z -> sequence arrow x z
-  a <| as = tsingleton a >< as
-
-  -- | Append two trees of operations
-  (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
-  l >< r = case tviewl l of
-    TOneL x -> x <| r
-    h :< t  -> h <| (t >< r)
-
-  -- | Left view deconstruction
-  tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y
-  tviewl q = case tviewr q of
-    TOneR x -> TOneL x
-    p :> l  -> case tviewl p of
-        TOneL x -> x :< tsingleton l
-        h :< t  -> h :< (t |> l)
-
-  -- | Right view deconstruction
-  tviewr :: sequence arrow x y -> TANonEmptyViewR sequence arrow x y
-  tviewr q = case tviewl q of
-    TOneL x -> TOneR x
-    h :< t  -> case tviewr t of
-        TOneR x -> tsingleton h :> x
-        p :> l  -> (h <| p)     :> l
-
-  -- | Map over leaf arrows
-  tmap :: (forall x y. arrow x y -> arrow' x y) -> sequence arrow x y -> sequence arrow' x y
-
-data TANonEmptyViewL s arrow a b where
-  TOneL :: arrow a b -> TANonEmptyViewL s arrow a b
-  (:<)  :: arrow a x -> s arrow x b -> TANonEmptyViewL s arrow a b
-
-data TANonEmptyViewR s arrow a b where
-  TOneR :: arrow a b                -> TANonEmptyViewR s arrow a b
-  (:>)  :: s arrow a x -> arrow x b -> TANonEmptyViewR s arrow a b
-
-instance TANonEmptySequence FTCQueue where
-  -- O(1)
-  tsingleton = Leaf
-  {-# INLINE tsingleton #-}
-
-  -- O(1)
-  t |> r = Node t (Leaf r)
-  {-# INLINE (|>) #-}
-
-  -- O(1)
-  t1 >< t2 = Node t1 t2
-  {-# INLINE (><) #-}
-
-  -- average O(1)
-  tviewl (Leaf r) = TOneL r
-  tviewl (Node t1 t2) = go t1 t2
-    where
-      go :: FTCQueue arrow a x -> FTCQueue arrow x b -> TANonEmptyViewL FTCQueue arrow a b
-      go (Leaf r) tr = r :< tr
-      go (Node tl1 tl2) tr = go tl1 (Node tl2 tr)
-
-  -- O(n)
-  tmap f (Leaf r) = Leaf (f r)
-  tmap f (Node l r) = Node (tmap f l) (tmap f r)
-
-
-instance Cat.Category arrow => Cat.Category (FTCQueue arrow) where
-  id = Leaf Cat.id
-  (.) = flip (><)
+type FTCQueue = BinaryTree

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -33,35 +33,35 @@ module Data.FTCQueue (
 -- |
 -- Non-empty tree. Deconstruction operations make it more and more
 -- left-leaning
-data FTCQueue m a b where
-  Leaf :: (a -> m b) -> FTCQueue m a b
-  Node :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
+data FTCQueue arrow a b where
+  Leaf :: (arrow a b) -> FTCQueue arrow a b
+  Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 
 -- | Build a leaf from a single operation [O(1)]
-tsingleton :: (a -> m b) -> FTCQueue m a b
+tsingleton :: arrow a b -> FTCQueue arrow a b
 tsingleton = Leaf
 {-# INLINE tsingleton #-}
 
 -- | Append an operation to the right of the tree [O(1)]
-(|>) :: FTCQueue m a x -> (x -> m b) -> FTCQueue m a b
+(|>) :: FTCQueue arrow a x -> arrow x b -> FTCQueue arrow a b
 t |> r = Node t (Leaf r)
 {-# INLINE (|>) #-}
 
 -- | Append two trees of operations [O(1)]
-(><)   :: FTCQueue m a x -> FTCQueue m x b -> FTCQueue m a b
+(><)   :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 t1 >< t2 = Node t1 t2
 {-# INLINE (><) #-}
 
 -- | Left view deconstruction data structure
-data ViewL m a b where
-  TOne  :: (a -> m b) -> ViewL m a b
-  (:<)  :: (a -> m x) -> FTCQueue m x b -> ViewL m a b
+data ViewL arrow a b where
+  TOne  :: arrow a b -> ViewL arrow a b
+  (:<)  :: arrow a x -> FTCQueue arrow x b -> ViewL arrow a b
 
 -- | Left view deconstruction [average O(1)]
-tviewl :: FTCQueue m a b -> ViewL m a b
+tviewl :: FTCQueue arrow a b -> ViewL arrow a b
 tviewl (Leaf r) = TOne r
 tviewl (Node t1 t2) = go t1 t2
  where
-   go :: FTCQueue m a x -> FTCQueue m x b -> ViewL m a b
+   go :: FTCQueue arrow a x -> FTCQueue arrow x b -> ViewL arrow a b
    go (Leaf r) tr = r :< tr
    go (Node tl1 tl2) tr = go tl1 (Node tl2 tr)

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -42,6 +42,7 @@ class TANonEmptySequence sequence where
 
   -- | Append an operation to the right of the tree [O(1)]
   (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
+  as |> a = as >< tsingleton a
 
   -- | Append two trees of operations [O(1)]
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -35,9 +35,13 @@ data FTCQueue arrow a b where
   Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 
 class TANonEmptySequence sequence where
+  -- | Build a leaf from a single operation [O(1)]
   tsingleton :: arrow x y -> sequence arrow x y
+  -- | Append an operation to the right of the tree [O(1)]
   (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
+  -- | Append two trees of operations [O(1)]
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
+  -- | Left view deconstruction [average O(1)]
   tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y
 
 data TANonEmptyViewL s arrow a b where
@@ -45,19 +49,15 @@ data TANonEmptyViewL s arrow a b where
   (:<)  :: arrow a x -> s arrow x b -> TANonEmptyViewL s arrow a b
 
 instance TANonEmptySequence FTCQueue where
-  -- | Build a leaf from a single operation [O(1)]
   tsingleton = Leaf
   {-# INLINE tsingleton #-}
 
-  -- | Append an operation to the right of the tree [O(1)]
   t |> r = Node t (Leaf r)
   {-# INLINE (|>) #-}
 
-  -- | Append two trees of operations [O(1)]
   t1 >< t2 = Node t1 t2
   {-# INLINE (><) #-}
 
-  -- | Left view deconstruction [average O(1)]
   tviewl (Leaf r) = TOne r
   tviewl (Node t1 t2) = go t1 t2
     where

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -37,7 +37,7 @@ data FTCQueue arrow a b where
   Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 
 class TANonEmptySequence sequence where
-  {-# MINIMAL tsingleton, (><), tviewl, tmap #-}
+  {-# MINIMAL tsingleton, ((><) | (<|)), tviewl, tmap #-}
   -- | Build a leaf from a single operation
   tsingleton :: arrow x y -> sequence arrow x y
 
@@ -51,6 +51,9 @@ class TANonEmptySequence sequence where
 
   -- | Append two trees of operations
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
+  l >< r = case tviewl l of
+    TOneL x -> x <| r
+    h :< t  -> h <| (t >< r)
 
   -- | Left view deconstruction
   tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -38,20 +38,20 @@ data FTCQueue arrow a b where
 
 class TANonEmptySequence sequence where
   {-# MINIMAL tsingleton, (><), tviewl, tmap #-}
-  -- | Build a leaf from a single operation [O(1)]
+  -- | Build a leaf from a single operation
   tsingleton :: arrow x y -> sequence arrow x y
 
-  -- | Append an operation to the right of the tree [O(1)]
+  -- | Append an operation to the right of the tree
   (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
   as |> a = as >< tsingleton a
 
-  -- | Append two trees of operations [O(1)]
+  -- | Append two trees of operations
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
 
-  -- | Left view deconstruction [average O(1)]
+  -- | Left view deconstruction
   tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y
 
-  -- | Map over leaf arrows [O(n)]
+  -- | Map over leaf arrows
   tmap :: (forall x y. arrow x y -> arrow' x y) -> sequence arrow x y -> sequence arrow' x y
 
 data TANonEmptyViewL s arrow a b where
@@ -59,15 +59,19 @@ data TANonEmptyViewL s arrow a b where
   (:<)  :: arrow a x -> s arrow x b -> TANonEmptyViewL s arrow a b
 
 instance TANonEmptySequence FTCQueue where
+  -- O(1)
   tsingleton = Leaf
   {-# INLINE tsingleton #-}
 
+  -- O(1)
   t |> r = Node t (Leaf r)
   {-# INLINE (|>) #-}
 
+  -- O(1)
   t1 >< t2 = Node t1 t2
   {-# INLINE (><) #-}
 
+  -- average O(1)
   tviewl (Leaf r) = TOneL r
   tviewl (Node t1 t2) = go t1 t2
     where
@@ -75,6 +79,7 @@ instance TANonEmptySequence FTCQueue where
       go (Leaf r) tr = r :< tr
       go (Node tl1 tl2) tr = go tl1 (Node tl2 tr)
 
+  -- O(n)
   tmap f (Leaf r) = Leaf (f r)
   tmap f (Node l r) = Node (tmap f l) (tmap f r)
 

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -37,6 +37,7 @@ data FTCQueue arrow a b where
   Node :: FTCQueue arrow a x -> FTCQueue arrow x b -> FTCQueue arrow a b
 
 class TANonEmptySequence sequence where
+  {-# MINIMAL tsingleton, (><), tviewl, tmap #-}
   -- | Build a leaf from a single operation [O(1)]
   tsingleton :: arrow x y -> sequence arrow x y
 

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -27,6 +27,8 @@ module Data.FTCQueue
 , TANonEmptyViewL(..)
 ) where
 
+import qualified Control.Category as Cat
+
 -- |
 -- Non-empty tree. Deconstruction operations make it more and more
 -- left-leaning
@@ -69,3 +71,8 @@ instance TANonEmptySequence FTCQueue where
 
   tmap f (Leaf r) = Leaf (f r)
   tmap f (Node l r) = Node (tmap f l) (tmap f r)
+
+
+instance Cat.Category arrow => Cat.Category (FTCQueue arrow) where
+  id = Leaf Cat.id
+  (.) = flip (><)

--- a/src/Data/FTCQueue.hs
+++ b/src/Data/FTCQueue.hs
@@ -39,12 +39,16 @@ data FTCQueue arrow a b where
 class TANonEmptySequence sequence where
   -- | Build a leaf from a single operation [O(1)]
   tsingleton :: arrow x y -> sequence arrow x y
+
   -- | Append an operation to the right of the tree [O(1)]
   (|>) :: sequence arrow x y -> arrow y z -> sequence arrow x z
+
   -- | Append two trees of operations [O(1)]
   (><) :: sequence arrow x y -> sequence arrow y z -> sequence arrow x z
+
   -- | Left view deconstruction [average O(1)]
   tviewl :: sequence arrow x y -> TANonEmptyViewL sequence arrow x y
+
   -- | Map over leaf arrows [O(n)]
   tmap :: (forall x y. arrow x y -> arrow' x y) -> sequence arrow x y -> sequence arrow' x y
 


### PR DESCRIPTION
Some steps towards #30:

1. Represent `Arrow` as a `newtype`, wrap & unwrap where necessary.
2. Parameterize `FTCQueue` by the type of arrows instead of assuming `->` with codomain in `m`.
3. Replace `FTCQueue` with `Data.TASequence.BinaryTree` & handle the `TAEmptyL` case in `apply` (the only place where we actually inspect the tree explicitly) by producing a `pure` value—`TAEmptyL` is type-indexed to `TAViewL s c x x`, which for us means `BinaryTree (Arrow effects) a a`, so `pure` will do just fine.

I’m pretty sure the performance of `BinaryTree` will be comparable to that of `FTCQueue`, since `BinaryTree`’s instance of `TASequence` never constructs `Empty` nodes unless explicitly requested to (with `tempty`, which we don’t call).

I haven’t yet swapped in a different type-aligned queue implementation or benchmarked any of it, and I especially haven’t benchmarked `master` against this, but it’s a start.