### PR TITLE
Refinement

### DIFF
--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -24,6 +24,7 @@ module Control.Monad.Effect (
   , interpret
   , reinterpret
   , reinterpret2
+  , refine
   -- * Checking a List of Effects#
   , Member
   , Members

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -27,7 +27,6 @@ module Control.Monad.Effect.Coroutine (
   runCoro
 ) where
 
-import Control.Monad ((<=<))
 import Control.Monad.Effect.Internal
 
 -- | A type representing a yielding of control
@@ -53,6 +52,4 @@ runC = relay (raiseEff . pure . Done) (\ (Yield a k) arr -> raiseEff (pure (Cont
 
 -- | Launch a thread and run it to completion using a helper function to provide new inputs.
 runCoro :: Effectful m => (a -> b) -> m (Yield a b ': e) w -> m e w
-runCoro f = raiseHandler (loop <=< runC)
-  where loop (Done a)       = pure a
-        loop (Continue a k) = k (f a) >>= loop
+runCoro f = raiseHandler (refine (\ (Yield a k) -> pure (k (f a))))

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -238,6 +238,8 @@ reinterpret2 handle = raiseHandler loop
 
 
 -- | Interpret an effect by iterated refinement.
+--
+--   Refinement is performed via a handler which is able to request the handled effect, essentially unfolding a computation by handling effects in terms of (in some sense) “smaller” effects until no more are present. Therefore, care must be taken not to introduce cycles by e.g. interpreting the effect in terms of itself (even indirectly).
 refine :: forall m eff effects a
        .  Effectful m
        => (forall result . eff result -> m (eff ': effects) result)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -237,7 +237,10 @@ reinterpret2 handle = raiseHandler loop
             Left  u   -> E (weaken (weaken u)) (tsingleton (q >>> loop))
 
 
-refine :: forall m eff effects a . Effectful m => (forall result . eff result -> m (eff ': effects) result) -> m (eff ': effects) a -> m effects a
+refine :: forall m eff effects a
+       .  Effectful m
+       => (forall result . eff result -> m (eff ': effects) result)
+       -> m (eff ': effects) a -> m effects a
 refine refinement = raiseHandler go
   where go :: Eff (eff ': effects) x -> Eff effects x
         go = relay pure (\ eff yield -> go (lowerEff (refinement eff)) >>= yield)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -237,6 +237,7 @@ reinterpret2 handle = raiseHandler loop
             Left  u   -> E (weaken (weaken u)) (tsingleton (q >>> loop))
 
 
+-- | Interpret an effect by iterated refinement.
 refine :: forall m eff effects a
        .  Effectful m
        => (forall result . eff result -> m (eff ': effects) result)


### PR DESCRIPTION
This PR adds a refinement-style handler useful for e.g. encoding proof refinement as effectful requests:

```haskell
data Check result where
  Check :: Term -> Type -> Check Type
  Infer :: Term         -> Check Type

runCheck = refine (\case
  Check (Abs var body) (Fn arg expected) ->
    Fn arg <$> local ((var, arg) :) (send (Infer body)) >>= unify expected
  …
  Check term ty -> send (Infer term) >>= unify ty
  Infer (Lit _) -> pure Bool
  …)
```

Here, the handler for checking and inference can request further checking and inference, but well-founded refinements will inevitably terminate by virtue of eventually servicing all requests for the `Check` effect. It’s rather like an anamorphism on the computation performed.