### PR TITLE
Role annotation

### DIFF
--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -49,7 +49,6 @@ module Data.Union (
 ) where
 
 import Unsafe.Coerce(unsafeCoerce)
-import GHC.Exts (Constraint)
 
 
 -- Strong Sum (Existential with the evidence) is an open union

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
 
 -- Only for MemberU below, when emulating Monad Transformers
 {-# LANGUAGE FunctionalDependencies, UndecidableInstances #-}
@@ -50,6 +51,8 @@ module Data.Union (
 
 import Unsafe.Coerce(unsafeCoerce)
 
+
+type role Union nominal nominal
 
 -- Strong Sum (Existential with the evidence) is an open union
 -- t is can be a GADT and hence not necessarily a Functor.


### PR DESCRIPTION
This PR gives an explicit role annotation for `Union`, fixing #52. Opened for comment since this does in fact break us, as (regrettably) expected.

- [x] Fixes #52.