### PR TITLE
Stateless effect handlers

### DIFF
--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -38,6 +38,8 @@ module Control.Monad.Effect
   , Member
   -- * Effects
   , Effects
+  , PureEffect(..)
+  , defaultHandle
   , Effect(..)
   , Lift(..)
   , Exc

--- a/src/Control/Monad/Effect.hs
+++ b/src/Control/Monad/Effect.hs
@@ -37,6 +37,7 @@ module Control.Monad.Effect
   -- * Checking a List of Effects
   , Member
   -- * Effects
+  , PureEffects
   , Effects
   , PureEffect(..)
   , defaultHandle

--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -71,5 +71,6 @@ runCoro f = raiseHandler (loop <=< runC)
         loop (Continue a k) = k (f a) >>= loop
 
 
+instance PureEffect (Yield a bs)
 instance Effect (Yield a bs) where
   handleState c dist (Request (Yield a f) k) = Request (Yield a f) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/Exception.hs
+++ b/src/Control/Monad/Effect/Exception.hs
@@ -49,7 +49,7 @@ throwError = send . Throw
 -- If there are no exceptions thrown, returns Right If exceptions are
 -- thrown and not handled, returns Left, interrupting the execution of
 -- any other effect handlers.
-runError :: (Effectful m, Effect (Union e)) => m (Exc exc ': e) a -> m e (Either exc a)
+runError :: (Effectful m, Effects e) => m (Exc exc ': e) a -> m e (Either exc a)
 runError = raiseHandler go
   where go (Return a)             = pure (Right a)
         go (Effect (Throw e) _)   = pure (Left e)

--- a/src/Control/Monad/Effect/Exception.hs
+++ b/src/Control/Monad/Effect/Exception.hs
@@ -73,6 +73,7 @@ handleError :: (Member (Exc exc) e, Effectful m) => (exc -> m e a) -> m e a -> m
 handleError = flip catchError
 
 
+instance PureEffect (Exc exc)
 instance Effect (Exc exc) where
   handleState c dist (Request (Throw exc) k) = Request (Throw exc) (dist . (<$ c) . k)
   handleState c dist (Request (Catch a h) k) = Request (Catch (dist (a <$ c)) (dist . (<$ c) . h)) (dist . fmap k)

--- a/src/Control/Monad/Effect/Fail.hs
+++ b/src/Control/Monad/Effect/Fail.hs
@@ -8,7 +8,7 @@ module Control.Monad.Effect.Fail
 import Control.Monad.Effect.Internal
 import Control.Monad.Fail
 
-runFail :: (Effectful m, Effect (Union effs)) => m (Fail ': effs) a -> m effs (Either String a)
+runFail :: (Effectful m, Effects effs) => m (Fail ': effs) a -> m effs (Either String a)
 runFail = raiseHandler go
   where go (Return a)          = pure (Right a)
         go (Effect (Fail s) _) = pure (Left s)

--- a/src/Control/Monad/Effect/Fresh.hs
+++ b/src/Control/Monad/Effect/Fresh.hs
@@ -53,6 +53,7 @@ runFresh i = raiseHandler (fmap snd . go i)
         go s (Other u k)             = liftStatefulHandler (s, ()) (uncurry go) u k
 
 
+instance PureEffect Fresh
 instance Effect Fresh where
   handleState c dist (Request Fresh k) = Request Fresh (dist . (<$ c) . k)
   handleState c dist (Request (Reset i a) k) = Request (Reset i (dist (a <$ c))) (dist . fmap k)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -15,6 +15,7 @@ module Control.Monad.Effect.Internal (
   , Request(..)
   , decomposeEff
   , Effects
+  , PureEffect(..)
   , Effect(..)
   , liftStatefulHandler
   , liftHandler
@@ -109,6 +110,11 @@ fromRequest (Request u k) = E u (tsingleton (Arrow k))
 decomposeEff :: Eff effects a -> Either a (Request (Union effects) (Eff effects) a)
 decomposeEff (Return a) = Left a
 decomposeEff (E u q) = Right (Request u (apply q))
+
+class PureEffect effect where
+  handle :: (forall x . m x -> n x)
+         -> Request effect m a
+         -> Request effect n a
 
 -- | Effects are higher-order (may themselves contain effectful actions), and as such must be able to thread an effect handler (structured as a distributive law) through themselves.
 class Effect effect where

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -116,10 +116,10 @@ class PureEffect effect where
   handle :: (forall x . m x -> n x)
          -> Request effect m a
          -> Request effect n a
-  default handle :: (Effect effect, Monad m, Monad n) => (forall x . m x -> n x) -> Request effect m a -> Request effect n a
+  default handle :: (Effect effect, Functor m, Functor n) => (forall x . m x -> n x) -> Request effect m a -> Request effect n a
   handle = defaultHandle
 
-defaultHandle :: (Effect effect, Monad m, Monad n)
+defaultHandle :: (Effect effect, Functor m, Functor n)
               => (forall x . m x -> n x)
               -> Request effect m a
               -> Request effect n a
@@ -130,7 +130,7 @@ class Effect effect where
   -- | Lift some initial state and a handler for some effect through another effect.
   --
   --   First-order effects (ones not using the @m@ parameter) have relatively simple definitions, more or less just pushing the distributive law through the continuation. Higher-order effects (like @Reader@’s @Local@ constructor) must additionally apply the handler to their scoped actions.
-  handleState :: (Functor c, Monad m, Monad n)
+  handleState :: (Functor c, Functor m, Functor n)
               => c ()
               -> (forall x . c (m x) -> n (c x))
               -> Request effect m a

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -257,7 +257,7 @@ runM m = case lowerEff m of
 -- * Local handlers
 
 -- | Listen for an effect, and take some action before re-sending it.
-eavesdrop :: (Member eff effects, Effectful m, Effects effects)
+eavesdrop :: (Member eff effects, Effectful m, PureEffects effects)
           => (forall v. eff (Eff effects) v -> m effects ())
           -> m effects a
           -> m effects a
@@ -269,7 +269,7 @@ eavesdrop listener = raiseHandler loop
 
 -- | Intercept the request and possibly reply to it, but leave it
 -- unhandled
-interpose :: (Member eff e, Effectful m, Effects e)
+interpose :: (Member eff e, Effectful m, PureEffects e)
           => (forall v. eff (Eff e) v -> m e v)
           -> m e a
           -> m e a

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -374,5 +374,6 @@ newtype Fail (m :: * -> *) a = Fail { failMessage :: String }
 instance Member Fail fs => MonadFail (Eff fs) where
   fail = send . Fail
 
+instance PureEffect Fail
 instance Effect Fail where
   handleState c dist (Request (Fail s) k) = Request (Fail s) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -113,7 +113,8 @@ decomposeEff (Return a) = Left a
 decomposeEff (E u q) = Right (Request u (apply q))
 
 class PureEffect effect where
-  handle :: (forall x . m x -> n x)
+  handle :: (Functor m, Functor n)
+         => (forall x . m x -> n x)
          -> Request effect m a
          -> Request effect n a
   default handle :: (Effect effect, Functor m, Functor n) => (forall x . m x -> n x) -> Request effect m a -> Request effect n a

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -362,6 +362,7 @@ instance Member NonDet a => MonadPlus (Eff a) where
   mzero       = send MZero
   mplus m1 m2 = send MPlus >>= \x -> if x then m1 else m2
 
+instance PureEffect NonDet
 instance Effect NonDet where
   handleState c dist (Request MZero k) = Request MZero (dist . (<$ c) . k)
   handleState c dist (Request MPlus k) = Request MPlus (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -147,8 +147,8 @@ liftStatefulHandler c handler u k = fromRequest (handleState c handler (Request 
 -- | Lift a pure effect handler through other effects in the 'Union'.
 --
 --   Useful when defining pure effect handlers (such as @runReader@).
-liftHandler :: Effects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
-liftHandler handler u k = runIdentity <$> liftStatefulHandler (Identity ()) (fmap Identity . handler . runIdentity) u k
+liftHandler :: PureEffects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
+liftHandler handler u k = fromRequest (handle handler (Request u k))
 
 instance PureEffect (Union '[])
 instance Effect (Union '[]) where

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -16,6 +16,7 @@ module Control.Monad.Effect.Internal (
   , decomposeEff
   , Effects
   , PureEffect(..)
+  , defaultHandle
   , Effect(..)
   , liftStatefulHandler
   , liftHandler
@@ -115,6 +116,12 @@ class PureEffect effect where
   handle :: (forall x . m x -> n x)
          -> Request effect m a
          -> Request effect n a
+
+defaultHandle :: (Effect effect, Monad m, Monad n)
+              => (forall x . m x -> n x)
+              -> Request effect m a
+              -> Request effect n a
+defaultHandle handler (Request u k) = runIdentity <$> handleState (Identity ()) (fmap Identity . handler . runIdentity) (Request u k)
 
 -- | Effects are higher-order (may themselves contain effectful actions), and as such must be able to thread an effect handler (structured as a distributive law) through themselves.
 class Effect effect where

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, DataKinds, DeriveFoldable, DeriveFunctor, DeriveTraversable, FlexibleContexts, FlexibleInstances, GADTs, GeneralizedNewtypeDeriving, KindSignatures, PatternSynonyms, RankNTypes, TypeOperators, UndecidableInstances, ViewPatterns #-}
+{-# LANGUAGE ConstraintKinds, DataKinds, DefaultSignatures, DeriveFoldable, DeriveFunctor, DeriveTraversable, FlexibleContexts, FlexibleInstances, GADTs, GeneralizedNewtypeDeriving, KindSignatures, PatternSynonyms, RankNTypes, TypeOperators, UndecidableInstances, ViewPatterns #-}
 module Control.Monad.Effect.Internal (
   -- * Constructing and Sending Effects
   Eff(..)
@@ -116,6 +116,8 @@ class PureEffect effect where
   handle :: (forall x . m x -> n x)
          -> Request effect m a
          -> Request effect n a
+  default handle :: (Effect effect, Monad m, Monad n) => (forall x . m x -> n x) -> Request effect m a -> Request effect n a
+  handle = defaultHandle
 
 defaultHandle :: (Effect effect, Monad m, Monad n)
               => (forall x . m x -> n x)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -344,6 +344,7 @@ instance Member (Lift IO) e => MonadIO (Eff e) where
 newtype Lift effect (m :: * -> *) a = Lift { unLift :: effect a }
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+instance PureEffect (Lift effect)
 instance Effect (Lift effect) where
   handleState c dist (Request (Lift op) k) = Request (Lift op) (dist . (<$ c) . k)
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -137,7 +137,7 @@ liftStatefulHandler c handler u k = fromRequest (handleState c handler (Request 
 --
 --   Useful when defining pure effect handlers (such as @runReader@).
 liftHandler :: Effects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
-liftHandler handler u k = raiseEff $ runIdentity <$> liftStatefulHandler (Identity ()) (fmap Identity . lowerHandler handler . runIdentity) u (lowerEff . k)
+liftHandler handler u k = runIdentity <$> liftStatefulHandler (Identity ()) (fmap Identity . handler . runIdentity) u k
 
 instance Effect (Union '[]) where
   handleState _ _ _ = error "impossible: handleState on empty Union"

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -147,8 +147,8 @@ liftStatefulHandler c handler u k = fromRequest (handleState c handler (Request 
 -- | Lift a pure effect handler through other effects in the 'Union'.
 --
 --   Useful when defining pure effect handlers (such as @runReader@).
-liftHandler :: PureEffects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
-liftHandler handler u k = fromRequest (handle handler (Request u k))
+liftHandler :: (Effectful m, PureEffects effects') => (forall x . m effects x -> m effects' x) -> Union effects' (Eff effects) b -> (b -> m effects a) -> m effects' a
+liftHandler handler u k = raiseEff (fromRequest (handle (lowerHandler handler) (Request u (lowerEff . k))))
 
 instance PureEffect (Union '[])
 instance Effect (Union '[]) where

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -127,7 +127,7 @@ defaultHandle :: (Effect effect, Functor m, Functor n)
 defaultHandle handler (Request u k) = runIdentity <$> handleState (Identity ()) (fmap Identity . handler . runIdentity) (Request u k)
 
 -- | Effects are higher-order (may themselves contain effectful actions), and as such must be able to thread an effect handler (structured as a distributive law) through themselves.
-class Effect effect where
+class PureEffect effect => Effect effect where
   -- | Lift some initial state and a handler for some effect through another effect.
   --
   --   First-order effects (ones not using the @m@ parameter) have relatively simple definitions, more or less just pushing the distributive law through the continuation. Higher-order effects (like @Reader@’s @Local@ constructor) must additionally apply the handler to their scoped actions.

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -14,6 +14,7 @@ module Control.Monad.Effect.Internal (
   , pattern Other2
   , Request(..)
   , decomposeEff
+  , PureEffects
   , Effects
   , PureEffect(..)
   , defaultHandle
@@ -163,6 +164,9 @@ instance (Effect effect, Effect (Union effects)) => Effect (Union (effect ': eff
     Left u' -> weaken `requestMap` handleState c dist (Request u' k)
     Right eff -> inj `requestMap` handleState c dist (Request eff k)
 
+
+-- | Require a 'PureEffect' instance for each effect in the list.
+type PureEffects effects = PureEffect (Union effects)
 
 -- | Require an 'Effect' instance for each effect in the list.
 type Effects effects = Effect (Union effects)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -149,6 +149,7 @@ liftStatefulHandler c handler u k = fromRequest (handleState c handler (Request 
 liftHandler :: Effects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
 liftHandler handler u k = runIdentity <$> liftStatefulHandler (Identity ()) (fmap Identity . handler . runIdentity) u k
 
+instance PureEffect (Union '[]) where
 instance Effect (Union '[]) where
   handleState _ _ _ = error "impossible: handleState on empty Union"
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -284,7 +284,7 @@ interpose handler = raiseHandler loop
 -- * Effect handlers
 
 -- | Handle the topmost effect by interpreting it into the underlying effects.
-interpret :: (Effectful m, Effects effs)
+interpret :: (Effectful m, PureEffects effs)
           => (forall v. eff (Eff (eff ': effs)) v -> m effs v)
           -> m (eff ': effs) a
           -> m effs a
@@ -295,7 +295,7 @@ interpret bind = raiseHandler loop
 
 
 -- | Interpret an effect by replacing it with another effect.
-reinterpret :: (Effectful m, Effects (newEffect ': effs))
+reinterpret :: (Effectful m, PureEffects (newEffect ': effs))
             => (forall v. effect (Eff (effect ': effs)) v -> m (newEffect ': effs) v)
             -> m (effect ': effs) a
             -> m (newEffect ': effs) a
@@ -305,7 +305,7 @@ reinterpret bind = raiseHandler loop
         loop (Other u k)    = liftHandler (reinterpret (lowerEff . bind)) (weaken u) k
 
 -- | Interpret an effect by replacing it with two new effects.
-reinterpret2 :: (Effectful m, Effects (newEffect1 ': newEffect2 ': effs))
+reinterpret2 :: (Effectful m, PureEffects (newEffect1 ': newEffect2 ': effs))
              => (forall v. effect (Eff (effect ': effs)) v -> m (newEffect1 ': newEffect2 ': effs) v)
              -> m (effect ': effs) a
              -> m (newEffect1 ': newEffect2 ': effs) a

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -149,7 +149,7 @@ liftStatefulHandler c handler u k = fromRequest (handleState c handler (Request 
 liftHandler :: Effects effects' => (forall x . Eff effects x -> Eff effects' x) -> Union effects' (Eff effects) b -> (b -> Eff effects a) -> Eff effects' a
 liftHandler handler u k = runIdentity <$> liftStatefulHandler (Identity ()) (fmap Identity . handler . runIdentity) u k
 
-instance PureEffect (Union '[]) where
+instance PureEffect (Union '[])
 instance Effect (Union '[]) where
   handleState _ _ _ = error "impossible: handleState on empty Union"
 

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -153,6 +153,11 @@ instance PureEffect (Union '[]) where
 instance Effect (Union '[]) where
   handleState _ _ _ = error "impossible: handleState on empty Union"
 
+instance (PureEffect effect, PureEffect (Union effects)) => PureEffect (Union (effect ': effects)) where
+  handle handler (Request u k) = case decompose u of
+    Left u' -> weaken `requestMap` handle handler (Request u' k)
+    Right eff -> inj `requestMap` handle handler (Request eff k)
+
 instance (Effect effect, Effect (Union effects)) => Effect (Union (effect ': effects)) where
   handleState c dist (Request u k) = case decompose u of
     Left u' -> weaken `requestMap` handleState c dist (Request u' k)

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -115,11 +115,11 @@ class Effect effect where
   -- | Lift some initial state and a handler for some effect through another effect.
   --
   --   First-order effects (ones not using the @m@ parameter) have relatively simple definitions, more or less just pushing the distributive law through the continuation. Higher-order effects (like @Reader@’s @Local@ constructor) must additionally apply the handler to their scoped actions.
-  handleState :: Functor c
+  handleState :: (Functor c, Monad m, Monad n)
               => c ()
-              -> (forall x . c (Eff effects x) -> Eff effects' (c x))
-              -> Request effect (Eff effects) a
-              -> Request effect (Eff effects') (c a)
+              -> (forall x . c (m x) -> n (c x))
+              -> Request effect m a
+              -> Request effect n (c a)
 
 -- | Lift a stateful effect handler through other effects in the 'Union'.
 --

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -68,6 +68,7 @@ local :: forall v b m e. (Member (Reader v) e, Effectful m) =>
 local f m = send (Local f (lowerEff m))
 
 
+instance PureEffect (Reader r)
 instance Effect (Reader r) where
   handleState c dist (Request Reader k) = Request Reader (dist . (<$ c) . k)
   handleState c dist (Request (Local f a) k) = Request (Local f (dist (a <$ c))) (dist . fmap k)

--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -51,9 +51,9 @@ asks :: (Member (Reader v) e, Effectful m) => (v -> a) -> m e a
 asks f = raiseEff (f <$> ask)
 
 -- | Handler for reader effects
-runReader :: (Effectful m, Effect (Union e)) => v -> m (Reader v ': e) a -> m e a
+runReader :: (Effectful m, PureEffects e) => v -> m (Reader v ': e) a -> m e a
 runReader = raiseHandler . go
-  where go :: Effect (Union e) => v -> Eff (Reader v ': e) a -> Eff e a
+  where go :: PureEffects e => v -> Eff (Reader v ': e) a -> Eff e a
         go _ (Return a)             = pure a
         go e (Effect Reader k)      = go e (k e)
         go e (Effect (Local f m) k) = go (f e) (m >>= k)

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -22,7 +22,7 @@ runResumable = raiseHandler go
         go (Other u k)          = liftStatefulHandler (Right ()) (either (pure . Left) runResumable) u k
 
 -- | Run a 'Resumable' effect in an 'Effectful' context, using a handler to resume computation.
-runResumableWith :: (Effectful m, Effects effects) => (forall resume . exc resume -> m effects resume) -> m (Resumable exc ': effects) a -> m effects a
+runResumableWith :: (Effectful m, PureEffects effects) => (forall resume . exc resume -> m effects resume) -> m (Resumable exc ': effects) a -> m effects a
 runResumableWith handler = interpret (\ (Resumable e) -> handler e)
 
 

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -15,14 +15,14 @@ newtype Resumable exc (m :: * -> *) a = Resumable (exc a)
 throwResumable :: (Member (Resumable exc) e, Effectful m) => exc v -> m e v
 throwResumable = send . Resumable
 
-runResumable :: (Effectful m, Effect (Union e)) => m (Resumable exc ': e) a -> m e (Either (SomeExc exc) a)
+runResumable :: (Effectful m, Effects e) => m (Resumable exc ': e) a -> m e (Either (SomeExc exc) a)
 runResumable = raiseHandler go
   where go (Return a)           = pure (Right a)
         go (Effect (Resumable e) _) = pure (Left (SomeExc e))
         go (Other u k)          = liftStatefulHandler (Right ()) (either (pure . Left) runResumable) u k
 
 -- | Run a 'Resumable' effect in an 'Effectful' context, using a handler to resume computation.
-runResumableWith :: (Effectful m, Effect (Union effects)) => (forall resume . exc resume -> m effects resume) -> m (Resumable exc ': effects) a -> m effects a
+runResumableWith :: (Effectful m, Effects effects) => (forall resume . exc resume -> m effects resume) -> m (Resumable exc ': effects) a -> m effects a
 runResumableWith handler = interpret (\ (Resumable e) -> handler e)
 
 

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -36,5 +36,6 @@ instance (Show1 exc) => Show (SomeExc exc) where
   showsPrec num (SomeExc exc) = liftShowsPrec (const (const id)) (const id) num exc
 
 
+instance PureEffect (Resumable exc)
 instance Effect (Resumable exc) where
   handleState c dist (Request (Resumable exc) k) = Request (Resumable exc) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -39,7 +39,7 @@ import Data.Proxy
 --------------------------------------------------------------------------------
 
 -- | Run a 'State s' effect given an effect and an initial state.
-runState :: (Effectful m, Effect (Union e)) => s -> m (State s ': e) b -> m e (s, b)
+runState :: (Effectful m, Effects e) => s -> m (State s ': e) b -> m e (s, b)
 runState = raiseHandler . go
   where go s (Return a)         = pure (s, a)
         go s (Effect Get k)     = runState s (k s)

--- a/src/Control/Monad/Effect/State.hs
+++ b/src/Control/Monad/Effect/State.hs
@@ -101,6 +101,7 @@ localState f action = raiseEff $ do
   pure v
 
 
+instance PureEffect (State s)
 instance Effect (State s) where
   handleState c dist (Request Get k) = Request Get (dist . (<$ c) . k)
   handleState c dist (Request (Put s) k) = Request (Put s) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/StateRW.hs
+++ b/src/Control/Monad/Effect/StateRW.hs
@@ -33,9 +33,9 @@ import Control.Monad.Effect.Writer
 import Control.Monad.Effect.Internal
 
 -- | State handler, using Reader/Writer effects
-runStateR :: (Effectful m, Effect (Union e)) => s -> m (Writer s ': Reader s ': e) a -> m e (s, a)
+runStateR :: (Effectful m, Effects e) => s -> m (Writer s ': Reader s ': e) a -> m e (s, a)
 runStateR = raiseHandler . go
-  where go :: Effect (Union e) => s -> Eff (Writer s ': Reader s ': e) a -> Eff e (s, a)
+  where go :: Effects e => s -> Eff (Writer s ': Reader s ': e) a -> Eff e (s, a)
         go s (Return a)                = pure (s, a)
         go _ (Effect2_1 (Writer s) k)  = go s (k ())
         go s (Effect2_2 Reader k)      = go s (k s)

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -54,5 +54,6 @@ runReturningTrace :: (Effectful m, Effect (Union effects)) => m (Trace ': effect
 runReturningTrace = raiseHandler (fmap (first reverse) . runState [] . reinterpret (\ (Trace s) -> modify' (s:)))
 
 
+instance PureEffect Trace
 instance Effect Trace where
   handleState c dist (Request (Trace s) k) = Request (Trace s) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -50,7 +50,7 @@ runIgnoringTrace :: (Effectful m, PureEffects effects) => m (Trace ': effects) a
 runIgnoringTrace = raiseHandler (interpret (\ (Trace _) -> pure ()))
 
 -- | Run a 'Trace' effect, accumulating the traced values into a list like a 'Writer'.
-runReturningTrace :: (Effectful m, Effect (Union effects)) => m (Trace ': effects) a -> m effects ([String], a)
+runReturningTrace :: (Effectful m, Effects effects) => m (Trace ': effects) a -> m effects ([String], a)
 runReturningTrace = raiseHandler (fmap (first reverse) . runState [] . reinterpret (\ (Trace s) -> modify' (s:)))
 
 

--- a/src/Control/Monad/Effect/Trace.hs
+++ b/src/Control/Monad/Effect/Trace.hs
@@ -42,11 +42,11 @@ trace :: (Member Trace e, Effectful m) => String -> m e ()
 trace = send . Trace
 
 -- | An IO handler for Trace effects. Prints output to stderr.
-runPrintingTrace :: (Member (Lift IO) effects, Effectful m, Effect (Union effects)) => m (Trace ': effects) a -> m effects a
+runPrintingTrace :: (Member (Lift IO) effects, Effectful m, PureEffects effects) => m (Trace ': effects) a -> m effects a
 runPrintingTrace = raiseHandler (interpret (\ (Trace s) -> liftIO (hPutStrLn stderr s)))
 
 -- | Run a 'Trace' effect, discarding the traced values.
-runIgnoringTrace :: (Effectful m, Effect (Union effects)) => m (Trace ': effects) a -> m effects a
+runIgnoringTrace :: (Effectful m, PureEffects effects) => m (Trace ': effects) a -> m effects a
 runIgnoringTrace = raiseHandler (interpret (\ (Trace _) -> pure ()))
 
 -- | Run a 'Trace' effect, accumulating the traced values into a list like a 'Writer'.

--- a/src/Control/Monad/Effect/Writer.hs
+++ b/src/Control/Monad/Effect/Writer.hs
@@ -43,5 +43,6 @@ runWriter = raiseHandler (go mempty)
         go w (Other u k)           = liftStatefulHandler (w, ()) (uncurry go) u k
 
 
+instance PureEffect (Writer o)
 instance Effect (Writer o) where
   handleState c dist (Request (Writer o) k) = Request (Writer o) (dist . (<$ c) . k)

--- a/src/Control/Monad/Effect/Writer.hs
+++ b/src/Control/Monad/Effect/Writer.hs
@@ -35,9 +35,9 @@ tell :: (Member (Writer o) e, Effectful m) => o -> m e ()
 tell = send . Writer
 
 -- | Simple handler for Writer effects
-runWriter :: (Monoid o, Effectful m, Effect (Union e)) => m (Writer o ': e) a -> m e (o, a)
+runWriter :: (Monoid o, Effectful m, Effects e) => m (Writer o ': e) a -> m e (o, a)
 runWriter = raiseHandler (go mempty)
-  where go :: (Monoid o, Effect (Union e)) => o -> Eff (Writer o ': e) a -> Eff e (o, a)
+  where go :: (Monoid o, Effects e) => o -> Eff (Writer o ': e) a -> Eff e (o, a)
         go w (Return a)            = pure (w, a)
         go w (Effect (Writer o) k) = go (w `mappend` o) (k ())
         go w (Other u k)           = liftStatefulHandler (w, ()) (uncurry go) u k


### PR DESCRIPTION
This PR:

- [x] Depends on #60.
- [x] Defines a `PureEffect` class of effect types which can thread pure (stateless) handlers through embedded actions but _not_ stateful ones. This includes types embedding actions which produce values at type indices, and is thus a larger class of effect than the class which `Effect` describes.
- [x] Defines a default implementation of `handle` in terms of an existing `Effect` instance, making it very easy to define new instances for the common case where we have an `Effect` instance.
- [x] Generalizes a number of definitions to operate over `PureEffect` instances instead of `Effect` instances.