### PR TITLE
Generalize bracket to PureEffects.

### DIFF
--- a/src/Control/Monad/Effect/Exception.hs
+++ b/src/Control/Monad/Effect/Exception.hs
@@ -95,7 +95,7 @@ rethrowing m = raiseEff (liftIO (Exc.try m) >>= either (throwError . Exc.toExcep
 -- Call 'catchIO' at the call site if you want to recover.
 bracket :: ( Member (Lift IO) e
            , Effectful m
-           , Effects e
+           , PureEffects e
            )
         => IO a
         -> (a -> IO b)


### PR DESCRIPTION
This PR corrects an oversight where `bracket` is constrained to `Effects` rather than `PureEffects` despite not using any stateful handlers.