### PR TITLE
Apply to q instead of k

### DIFF
--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -277,7 +277,7 @@ interpose handler = raiseHandler loop
   where loop (Return a) = pure a
         loop (E u q) = case prj u of
           Just eff -> lowerEff (handler eff) >>= k
-          _        -> liftHandler (interpose (lowerEff . handler)) u k
+          _        -> liftHandler (interpose (lowerEff . handler)) u (apply q)
           where k = q >>> loop
 
 


### PR DESCRIPTION
We thread `interpose` through the rest of the effects but then we're also applying it to the continuation again. Changes `interpose` to just apply it to `q`.