### PR TITLE
Apply local’s effects locally-only.

### DIFF
--- a/src/Control/Monad/Effect/Reader.hs
+++ b/src/Control/Monad/Effect/Reader.hs
@@ -56,7 +56,7 @@ runReader = raiseHandler . go
   where go :: PureEffects e => v -> Eff (Reader v ': e) a -> Eff e a
         go _ (Return a)             = pure a
         go e (Effect Reader k)      = go e (k e)
-        go e (Effect (Local f m) k) = go (f e) (m >>= k)
+        go e (Effect (Local f m) k) = go (f e) m >>= go e . k
         go e (Other u k)            = liftHandler (go e) u k
 
 -- |


### PR DESCRIPTION
`local` was applying its effects to the continuation.

**master:**

```haskell
λ Effect.run (runReader (1 :: Int) (local (succ :: Int -> Int) ask) :: Eff '[] Int)
2
λ Effect.run (runReader (1 :: Int) (local (succ :: Int -> Int) (ask :: Eff '[Reader Int] Int) >> ask) :: Eff '[] Int)
2
```

**this PR:**

```haskell
λ Effect.run (runReader (1 :: Int) (local (succ :: Int -> Int) ask) :: Eff '[] Int)
2
λ Effect.run (runReader (1 :: Int) (local (succ :: Int -> Int) (ask :: Eff '[Reader Int] Int) >> ask) :: Eff '[] Int)
1
```