### PR TITLE
Efficient effect handling

### DIFF
--- a/src/Control/Monad/Effect/Coroutine.hs
+++ b/src/Control/Monad/Effect/Coroutine.hs
@@ -54,7 +54,7 @@ status :: (w -> x) -> (a -> (b -> m e (Status m e a b w)) -> x) -> Status m e a 
 status f _ (Done w) = f w
 status _ g (Continue a f) = g a f
 
-joinStatus :: Effect (Union effs) => Status Eff effs a b (Eff (Yield a b : effs) x) -> Eff effs (Status Eff effs a b x)
+joinStatus :: Effects effs => Status Eff effs a b (Eff (Yield a b : effs) x) -> Eff effs (Status Eff effs a b x)
 joinStatus = status runC (\ a f -> pure (Continue a (joinStatus <=< f)))
 
 -- | Launch a thread and report its status

--- a/src/Control/Monad/Effect/Internal.hs
+++ b/src/Control/Monad/Effect/Internal.hs
@@ -159,11 +159,11 @@ liftHandler handler u k = raiseEff (fromRequest (handle (lowerHandler handler) (
 {-# INLINE liftHandler #-}
 
 instance ForAll PureEffect effects => PureEffect (Union effects) where
-  handle handler (Request u k) = case' @PureEffect (\ reinj eff -> reinj `requestMap` handle handler (Request eff k)) u
+  handle handler (Request u k) = forAll @PureEffect (\ reinj eff -> reinj `requestMap` handle handler (Request eff k)) u
   {-# INLINE handle #-}
 
 instance (ForAll PureEffect effects, ForAll Effect effects) => Effect (Union effects) where
-  handleState state handler (Request u k) = case' @Effect (\ reinj eff -> reinj `requestMap` handleState state handler (Request eff k)) u
+  handleState state handler (Request u k) = forAll @Effect (\ reinj eff -> reinj `requestMap` handleState state handler (Request eff k)) u
   {-# INLINE handleState #-}
 
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -114,7 +114,11 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 type ForAll typeclass members = ForAll' typeclass members
 
 -- | Lift an operation generalized over any possible member of a 'Union' into the 'Union'.
-forAll :: forall typeclass members m a c . ForAll typeclass members => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c) -> Union members m a -> c
+forAll :: forall typeclass members m a c
+       .  ForAll typeclass members
+       => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c)
+       -> Union members m a
+       -> c
 forAll f = forAll' @typeclass @members @members f 0
 {-# INLINE forAll #-}
 

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -108,6 +108,9 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 {-# INLINE decompose0 #-}
 
 
+-- | A constraint synonym stating that all members of a 'Union' satisfy some constraint.
+--
+--   This is used to lift operations on members (made available by some typeclass) into operations on 'Union's.
 type ForAll typeclass members = ForAll' typeclass members
 
 forAll :: forall typeclass members m a c . ForAll typeclass members => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c) -> Union members m a -> c

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -36,7 +36,7 @@ module Data.Union
 , prj
 , Member
 , ForAll
-, case'
+, forAll
 ) where
 
 import Unsafe.Coerce (unsafeCoerce)
@@ -110,20 +110,20 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 
 type ForAll typeclass members = ForAll' typeclass members
 
-case' :: forall typeclass members m a c . ForAll typeclass members => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c) -> Union members m a -> c
-case' f = case'' @typeclass @members @members f 0
-{-# INLINE case' #-}
+forAll :: forall typeclass members m a c . ForAll typeclass members => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c) -> Union members m a -> c
+forAll f = forAll' @typeclass @members @members f 0
+{-# INLINE forAll #-}
 
 
 class ForAll' typeclass (members :: [(* -> *) -> (* -> *)]) where
-  case'' :: (forall member . typeclass member => (forall n b . member n b -> Union original n b) -> member m a -> c) -> Int -> Union original m a -> c
+  forAll' :: (forall member . typeclass member => (forall n b . member n b -> Union original n b) -> member m a -> c) -> Int -> Union original m a -> c
 
 instance ForAll' typeclass '[] where
-  case'' _ _ _ = error "impossible: case'' on empty Union"
-  {-# INLINE case'' #-}
+  forAll' _ _ _ = error "impossible: forAll' on empty Union"
+  {-# INLINE forAll' #-}
 
 instance (typeclass member, ForAll' typeclass members) => ForAll' typeclass (member ': members) where
-  case'' f n u@(Union n' t)
+  forAll' f n u@(Union n' t)
     | n == n'   = f @member (Union n') (unsafeCoerce t)
-    | otherwise = case'' @typeclass @members f (n + 1) u
-  {-# INLINE case'' #-}
+    | otherwise = forAll' @typeclass @members f (n + 1) u
+  {-# INLINE forAll' #-}

--- a/src/Data/Union.hs
+++ b/src/Data/Union.hs
@@ -113,6 +113,7 @@ decompose0 (Union _ v) = Right $ unsafeCoerce v
 --   This is used to lift operations on members (made available by some typeclass) into operations on 'Union's.
 type ForAll typeclass members = ForAll' typeclass members
 
+-- | Lift an operation generalized over any possible member of a 'Union' into the 'Union'.
 forAll :: forall typeclass members m a c . ForAll typeclass members => (forall member . typeclass member => (forall n b . member n b -> Union members n b) -> member m a -> c) -> Union members m a -> c
 forAll f = forAll' @typeclass @members @members f 0
 {-# INLINE forAll #-}


### PR DESCRIPTION
This PR defines a `forAll` function, lifting typeclass methods into `Union`s much like the old `ApplyAll` class did. Unlike `ApplyAll`, it’s defined inductively on the member list. While we aren’t (currently) able to flatten the nested `case`s out into (effectively) an O(1) `switch`, using `forAll` to define `PureEffect` & `Effect` instances for `Union`s results in a fairly dramatic reduction in allocations, and a slight speedup.

Depends on #66.
