### PR TITLE
Implement a Resource effect and remove broken `bracket`.

### DIFF
--- a/effects.cabal
+++ b/effects.cabal
@@ -45,6 +45,7 @@ library
                      , Control.Monad.Effect.NonDet
                      , Control.Monad.Effect.Reader
                      , Control.Monad.Effect.Resumable
+                     , Control.Monad.Effect.Resource
                      , Control.Monad.Effect.State
                      , Control.Monad.Effect.StateRW
                      , Control.Monad.Effect.Trace

--- a/src/Control/Monad/Effect/Resource.hs
+++ b/src/Control/Monad/Effect/Resource.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds, FlexibleContexts, GADTs, RankNTypes, TypeOperators #-}
+
+{-|
+Cleanup handlers for precise resource management.
+-}
+
+module Control.Monad.Effect.Resource
+  ( Resource (..)
+  , bracket
+  , runResource
+  ) where
+
+import           Control.Monad.Effect
+import           Control.Monad.IO.Class
+import qualified Control.Exception as Exc
+
+data Resource m output where
+  Resource :: m res -> (res -> m any) -> (res -> m output) -> Resource m output
+
+instance PureEffect Resource
+instance Effect Resource where
+  handleState c dist (Request (Resource fore aft go) k)
+    = Request (Resource (dist (fore <$ c)) (dist . fmap aft) (dist . fmap go)) (dist . fmap k)
+
+bracket :: (Member Resource effs, Effectful m)
+        => m effs res
+        -> (res -> m effs any)
+        -> (res -> m effs b)
+        -> m effs b
+bracket fore aft go = send (Resource (lowerEff fore) (lowerEff . aft) (lowerEff . go))
+
+runResource :: (Member (Lift IO) effects, PureEffects effects)
+            => (forall x . Eff effects x -> IO x)
+            -> Eff (Resource ': effects) a
+            -> Eff effects a
+runResource handler = interpret (\(Resource fore aft go)
+                                 -> liftIO (Exc.bracket
+                                            (handler (runResource handler fore))
+                                            (handler . runResource handler . aft)
+                                            (handler . runResource handler . go)))


### PR DESCRIPTION
The current formulation of `bracket` is broken in the presence of
asynchronous exceptions. If the action passed to `bracket` rethrows an
exception, and the exception is delivered asynchronously, there can
occur a race where the cleanup handler is invoked twice, which is
disastrous in terms of correctness.

The correct way to do this is to use `Control.Exception.bracket`, which
correctly masks asynchronous exceptions while executing the body of a
`bracket` call. We accomplish this by creating a new `Resource` effect
that uses `interpret` and a natural transformation to `IO` to invoke
the `bracket` function provided by `base`.