### PR TITLE
Add NFData instance for Resumable's SomeExc type.

### DIFF
--- a/effects.cabal
+++ b/effects.cabal
@@ -52,6 +52,7 @@ library
                      , Control.Monad.Effect.Writer
                      , Data.Union
   build-depends:       base >=4.7 && <5
+                     , deepseq
                      , type-aligned
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/src/Control/Monad/Effect/Resumable.hs
+++ b/src/Control/Monad/Effect/Resumable.hs
@@ -7,6 +7,7 @@ module Control.Monad.Effect.Resumable
   , runResumableWith
   ) where
 
+import Control.DeepSeq
 import Control.Monad.Effect.Internal
 import Data.Functor.Classes
 
@@ -35,6 +36,8 @@ instance Eq1 exc => Eq (SomeExc exc) where
 instance (Show1 exc) => Show (SomeExc exc) where
   showsPrec num (SomeExc exc) = liftShowsPrec (const (const id)) (const id) num exc
 
+instance NFData1 exc => NFData (SomeExc exc) where
+  rnf (SomeExc exc) = liftRnf (\a -> seq a ()) exc
 
 instance PureEffect (Resumable exc)
 instance Effect (Resumable exc) where


### PR DESCRIPTION
If you're benchmarking the result of running an effect that supports
resumable exceptions, you'll want to have both sides of the resulting
`Either` implement `NFData` so that you can fully evaluate the result.

Unfortunately, `SomeExc` didn't implement `NFData`, so the `NFData`
instance for `Either (SomeExc exc) a` couldn't kick in. This patch
fixes that.

I'm not thrilled about adding another dependency, but `deepseq` is
ubiquitous in the ecosystem at this point.